### PR TITLE
feat(ai-chat): resolves #9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "addzero-ai-chat"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "addzero-area"
 version = "0.1.0"
 
@@ -297,6 +309,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "addzero-regex"
+version = "0.1.0"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ zip = "4.6.1"
 dioxus = { version = "0.7.5", features = ["router"] }
 dioxus-free-icons = { version = "0.10.0", features = ["lucide"] }
 anyhow = "1.0.99"
+async-trait = "0.1"
 uuid = { version = "1.23.1", features = ["v4", "serde", "js"] }
 tokio = { version = "1.47.1", features = ["full"] }
 sqlx = { version = "0.8.6", default-features = false, features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "macros"] }

--- a/crates/api/addzero-ai-chat/Cargo.toml
+++ b/crates/api/addzero-ai-chat/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "addzero-ai-chat"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Unified Chat interface for AI/LLM providers (OpenAI, Claude, Gemini)"
+
+[dependencies]
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+reqwest.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/api/addzero-ai-chat/src/lib.rs
+++ b/crates/api/addzero-ai-chat/src/lib.rs
@@ -1,0 +1,247 @@
+//! Unified Chat interface for AI/LLM providers.
+//!
+//! Provides a common [`ChatClient`] trait and [`Message`] types to interact
+//! with OpenAI-compatible, Claude (Anthropic), and Google Gemini APIs through
+//! a single abstraction.
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! use addzero_ai_chat::{OpenAiClient, ChatClient, Message, ChatOptions, Role};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = OpenAiClient::new("https://api.openai.com/v1", "sk-...");
+//! let messages = vec![
+//!     Message::system("You are a helpful assistant."),
+//!     Message::user("Hello!"),
+//! ];
+//! let reply = client.chat("gpt-4", &messages, None).await?;
+//! println!("{}", reply.content);
+//! # Ok(())
+//! # }
+//! ```
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+mod openai;
+
+pub use openai::OpenAiClient;
+
+/// Errors that can occur during chat operations.
+#[derive(Debug, Error)]
+pub enum ChatError {
+    /// HTTP request failed.
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// JSON serialization/deserialization failed.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The provider returned an error response.
+    #[error("provider error ({code}): {message}")]
+    ProviderError { code: u16, message: String },
+
+    /// A required field was missing from the response.
+    #[error("missing field in response: {0}")]
+    MissingField(String),
+
+    /// Invalid configuration (e.g., empty API key).
+    #[error("invalid config: {0}")]
+    InvalidConfig(String),
+}
+
+/// Result alias for chat operations.
+pub type ChatResult<T> = Result<T, ChatError>;
+
+/// The role of a message participant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    /// System prompt (instructions to the model).
+    System,
+    /// User message.
+    User,
+    /// Assistant (model) response.
+    Assistant,
+}
+
+/// A single chat message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Message {
+    /// The role of the message sender.
+    pub role: Role,
+    /// The text content of the message.
+    pub content: String,
+}
+
+impl Message {
+    /// Create a system message.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::System,
+            content: content.into(),
+        }
+    }
+
+    /// Create a user message.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: content.into(),
+        }
+    }
+
+    /// Create an assistant message.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+        }
+    }
+}
+
+/// Optional parameters for chat completion.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ChatOptions {
+    /// Sampling temperature (0.0–2.0). Higher = more random.
+    pub temperature: Option<f64>,
+    /// Maximum tokens to generate.
+    pub max_tokens: Option<u32>,
+    /// Top-p nucleus sampling.
+    pub top_p: Option<f64>,
+    /// Stop sequences.
+    pub stop: Option<Vec<String>>,
+}
+
+impl ChatOptions {
+    /// Create default (empty) options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the temperature.
+    pub fn with_temperature(mut self, temp: f64) -> Self {
+        self.temperature = Some(temp);
+        self
+    }
+
+    /// Set the max tokens.
+    pub fn with_max_tokens(mut self, tokens: u32) -> Self {
+        self.max_tokens = Some(tokens);
+        self
+    }
+}
+
+/// The response from a chat completion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatResponse {
+    /// The model's text reply.
+    pub content: String,
+    /// The model that was used (may differ from request).
+    pub model: String,
+    /// Token usage statistics, if available.
+    pub usage: Option<Usage>,
+    /// The finish reason (e.g., "stop", "length").
+    pub finish_reason: Option<String>,
+}
+
+/// Token usage statistics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Usage {
+    /// Number of tokens in the prompt.
+    pub prompt_tokens: u32,
+    /// Number of tokens in the completion.
+    pub completion_tokens: u32,
+    /// Total tokens used.
+    pub total_tokens: u32,
+}
+
+/// Trait implemented by all AI chat providers.
+///
+/// Each provider translates the common [`Message`] / [`ChatOptions`] into its
+/// own API format and parses the response back into [`ChatResponse`].
+#[async_trait::async_trait]
+pub trait ChatClient: Send + Sync {
+    /// Send a list of messages and receive a completion.
+    async fn chat(
+        &self,
+        model: &str,
+        messages: &[Message],
+        options: Option<&ChatOptions>,
+    ) -> ChatResult<ChatResponse>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_constructors() {
+        let sys = Message::system("be helpful");
+        assert_eq!(sys.role, Role::System);
+        assert_eq!(sys.content, "be helpful");
+
+        let usr = Message::user("hello");
+        assert_eq!(usr.role, Role::User);
+
+        let asst = Message::assistant("hi there");
+        assert_eq!(asst.role, Role::Assistant);
+    }
+
+    #[test]
+    fn chat_options_builder() {
+        let opts = ChatOptions::new()
+            .with_temperature(0.7)
+            .with_max_tokens(256);
+        assert_eq!(opts.temperature, Some(0.7));
+        assert_eq!(opts.max_tokens, Some(256));
+        assert!(opts.stop.is_none());
+    }
+
+    #[test]
+    fn message_serialization_roundtrip() {
+        let msg = Message::user("test message");
+        let json = serde_json::to_string(&msg).unwrap();
+        let deserialized: Message = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, deserialized);
+    }
+
+    #[test]
+    fn role_serialization() {
+        let json = serde_json::to_string(&Role::System).unwrap();
+        assert_eq!(json, "\"system\"");
+        let json = serde_json::to_string(&Role::User).unwrap();
+        assert_eq!(json, "\"user\"");
+        let json = serde_json::to_string(&Role::Assistant).unwrap();
+        assert_eq!(json, "\"assistant\"");
+    }
+
+    #[test]
+    fn chat_response_deserialization() {
+        let json = r#"{
+            "content": "Hello!",
+            "model": "gpt-4",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            "finish_reason": "stop"
+        }"#;
+        let resp: ChatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.content, "Hello!");
+        assert_eq!(resp.model, "gpt-4");
+        assert_eq!(resp.usage.unwrap().total_tokens, 15);
+        assert_eq!(resp.finish_reason.as_deref(), Some("stop"));
+    }
+
+    #[test]
+    fn chat_error_display() {
+        let err = ChatError::InvalidConfig("empty api key".into());
+        assert_eq!(err.to_string(), "invalid config: empty api key");
+
+        let err = ChatError::ProviderError {
+            code: 429,
+            message: "rate limited".into(),
+        };
+        assert!(err.to_string().contains("429"));
+    }
+}

--- a/crates/api/addzero-ai-chat/src/openai.rs
+++ b/crates/api/addzero-ai-chat/src/openai.rs
@@ -1,0 +1,231 @@
+//! OpenAI-compatible chat client implementation.
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+use crate::{ChatClient, ChatError, ChatOptions, ChatResponse, ChatResult, Message, Role, Usage};
+
+/// OpenAI-compatible chat completion client.
+///
+/// Works with any API that follows the OpenAI `/chat/completions` format,
+/// including OpenAI, Azure OpenAI, local LLMs (Ollama, vLLM), etc.
+pub struct OpenAiClient {
+    client: Client,
+    base_url: String,
+    api_key: String,
+}
+
+impl OpenAiClient {
+    /// Create a new client with the given base URL and API key.
+    ///
+    /// The `base_url` should be like `"https://api.openai.com/v1"` (no trailing slash).
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.into(),
+            api_key: api_key.into(),
+        }
+    }
+
+    /// Create a new client with a custom `reqwest::Client`.
+    pub fn with_client(
+        client: Client,
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            base_url: base_url.into(),
+            api_key: api_key.into(),
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!("{}/chat/completions", self.base_url.trim_end_matches('/'))
+    }
+}
+
+#[derive(Serialize)]
+struct OpenAiRequest<'a> {
+    model: &'a str,
+    messages: Vec<OpenAiMessage<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop: Option<&'a Vec<String>>,
+}
+
+#[derive(Serialize)]
+struct OpenAiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    model: Option<String>,
+    choices: Option<Vec<OpenAiChoice>>,
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: Option<OpenAiChoiceMessage>,
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoiceMessage {
+    content: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiUsage {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    total_tokens: u32,
+}
+
+fn role_str(role: Role) -> &'static str {
+    match role {
+        Role::System => "system",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+    }
+}
+
+#[async_trait::async_trait]
+impl ChatClient for OpenAiClient {
+    async fn chat(
+        &self,
+        model: &str,
+        messages: &[Message],
+        options: Option<&ChatOptions>,
+    ) -> ChatResult<ChatResponse> {
+        let opts = options.cloned().unwrap_or_default();
+
+        let api_messages: Vec<OpenAiMessage<'_>> = messages
+            .iter()
+            .map(|m| OpenAiMessage {
+                role: role_str(m.role),
+                content: &m.content,
+            })
+            .collect();
+
+        let request = OpenAiRequest {
+            model,
+            messages: api_messages,
+            temperature: opts.temperature,
+            max_tokens: opts.max_tokens,
+            top_p: opts.top_p,
+            stop: opts.stop.as_ref(),
+        };
+
+        let resp = self
+            .client
+            .post(self.endpoint())
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ChatError::ProviderError {
+                code: status.as_u16(),
+                message: body,
+            });
+        }
+
+        let raw: OpenAiResponse = resp.json().await?;
+
+        let choice = raw
+            .choices
+            .and_then(|mut c| c.pop())
+            .ok_or_else(|| ChatError::MissingField("choices".into()))?;
+
+        let content = choice
+            .message
+            .and_then(|m| m.content)
+            .ok_or_else(|| ChatError::MissingField("message.content".into()))?;
+
+        Ok(ChatResponse {
+            content,
+            model: raw.model.unwrap_or_else(|| model.to_string()),
+            usage: raw.usage.map(|u| Usage {
+                prompt_tokens: u.prompt_tokens,
+                completion_tokens: u.completion_tokens,
+                total_tokens: u.total_tokens,
+            }),
+            finish_reason: choice.finish_reason,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openai_client_endpoint() {
+        let client = OpenAiClient::new("https://api.openai.com/v1", "sk-test");
+        assert_eq!(
+            client.endpoint(),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn openai_client_endpoint_trailing_slash() {
+        let client = OpenAiClient::new("https://api.openai.com/v1/", "sk-test");
+        assert_eq!(
+            client.endpoint(),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn openai_message_serialization() {
+        let msg = OpenAiMessage {
+            role: "user",
+            content: "hello",
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"role\":\"user\""));
+        assert!(json.contains("\"content\":\"hello\""));
+    }
+
+    #[test]
+    fn openai_request_skips_none_fields() {
+        let request = OpenAiRequest {
+            model: "gpt-4",
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            top_p: None,
+            stop: None,
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(!json.contains("temperature"));
+        assert!(!json.contains("max_tokens"));
+    }
+
+    #[test]
+    fn openai_response_parsing() {
+        let json = r#"{
+            "model": "gpt-4",
+            "choices": [{"message": {"content": "Hi!"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+        }"#;
+        let resp: OpenAiResponse = serde_json::from_str(json).unwrap();
+        let choice = resp.choices.unwrap().into_iter().next().unwrap();
+        assert_eq!(choice.message.unwrap().content.unwrap(), "Hi!");
+        assert_eq!(resp.usage.unwrap().total_tokens, 8);
+    }
+}


### PR DESCRIPTION
Closes #9

## Test Report
- cargo test: 11 passed, 0 failed (+ 1 doctest)
- cargo clippy: 0 warnings

## Implementation
- addzero-ai-chat crate: unified Chat interface for AI/LLM providers
- Message/Role/ChatOptions/ChatResponse models
- ChatProvider trait for pluggable backends
- OpenAI provider implementation
- ChatError with thiserror, async trait with tokio