### PR TITLE
feat(ddl-generator): resolves #22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addzero-ddl-generator"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "addzero-dict-macros"
 version = "0.1.0"
 dependencies = [
@@ -297,6 +306,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "addzero-regex"
+version = "0.1.0"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/data/addzero-ddl-generator/Cargo.toml
+++ b/crates/data/addzero-ddl-generator/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "addzero-ddl-generator"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "DDL statement generator supporting multiple database dialects"
+
+[dependencies]
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/data/addzero-ddl-generator/src/column.rs
+++ b/crates/data/addzero-ddl-generator/src/column.rs
@@ -1,0 +1,139 @@
+use serde::{Deserialize, Serialize};
+
+/// Supported SQL column types.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ColumnType {
+    /// Boolean type.
+    Boolean,
+    /// Signed 32-bit integer.
+    Integer,
+    /// Signed 64-bit integer.
+    BigInt,
+    /// Floating-point number.
+    Float,
+    /// Double-precision floating-point.
+    Double,
+    /// Fixed-length character string.
+    Char(u32),
+    /// Variable-length character string with max length.
+    Varchar(u32),
+    /// Unlimited-length text.
+    Text,
+    /// Binary large object.
+    Blob,
+    /// Date without time.
+    Date,
+    /// Date and time.
+    DateTime,
+    /// Timestamp with timezone.
+    Timestamp,
+    /// JSON document.
+    Json,
+    /// UUID value.
+    Uuid,
+}
+
+/// Represents a single column in a table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Column {
+    /// Column name.
+    pub name: String,
+    /// Column data type.
+    pub column_type: ColumnType,
+    /// Whether the column is a primary key.
+    pub primary_key: bool,
+    /// Whether the column is NOT NULL.
+    pub not_null: bool,
+    /// Whether the column has a UNIQUE constraint.
+    pub unique: bool,
+    /// Optional default value expression.
+    pub default: Option<String>,
+    /// Optional comment.
+    pub comment: Option<String>,
+}
+
+impl Column {
+    /// Create a new column with the given name and type.
+    pub fn new(name: impl Into<String>, column_type: ColumnType) -> Self {
+        Self {
+            name: name.into(),
+            column_type,
+            primary_key: false,
+            not_null: false,
+            unique: false,
+            default: None,
+            comment: None,
+        }
+    }
+
+    /// Mark this column as a primary key.
+    pub fn primary_key(mut self) -> Self {
+        self.primary_key = true;
+        self
+    }
+
+    /// Mark this column as NOT NULL.
+    pub fn not_null(mut self) -> Self {
+        self.not_null = true;
+        self
+    }
+
+    /// Mark this column as UNIQUE.
+    pub fn unique(mut self) -> Self {
+        self.unique = true;
+        self
+    }
+
+    /// Set a default value expression.
+    pub fn default(mut self, value: impl Into<String>) -> Self {
+        self.default = Some(value.into());
+        self
+    }
+
+    /// Add a comment to this column.
+    pub fn comment(mut self, text: impl Into<String>) -> Self {
+        self.comment = Some(text.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_builder_chain() {
+        let col = Column::new("id", ColumnType::BigInt)
+            .primary_key()
+            .not_null()
+            .default("0")
+            .comment("primary key");
+
+        assert_eq!(col.name, "id");
+        assert_eq!(col.column_type, ColumnType::BigInt);
+        assert!(col.primary_key);
+        assert!(col.not_null);
+        assert_eq!(col.default.as_deref(), Some("0"));
+        assert_eq!(col.comment.as_deref(), Some("primary key"));
+    }
+
+    #[test]
+    fn column_type_serialization_roundtrip() {
+        let col_type = ColumnType::Varchar(255);
+        let json = serde_json::to_string(&col_type).unwrap();
+        let deserialized: ColumnType = serde_json::from_str(&json).unwrap();
+        assert_eq!(col_type, deserialized);
+    }
+
+    #[test]
+    fn column_serialization_roundtrip() {
+        let col = Column::new("email", ColumnType::Varchar(255))
+            .unique()
+            .not_null();
+        let json = serde_json::to_string(&col).unwrap();
+        let deserialized: Column = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.name, "email");
+        assert!(deserialized.unique);
+        assert!(deserialized.not_null);
+    }
+}

--- a/crates/data/addzero-ddl-generator/src/dialect.rs
+++ b/crates/data/addzero-ddl-generator/src/dialect.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+/// Supported SQL database dialects for DDL generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Dialect {
+    /// MySQL / MariaDB.
+    MySQL,
+    /// PostgreSQL.
+    PostgreSQL,
+    /// SQLite.
+    SQLite,
+}

--- a/crates/data/addzero-ddl-generator/src/generator.rs
+++ b/crates/data/addzero-ddl-generator/src/generator.rs
@@ -1,0 +1,348 @@
+use crate::column::{Column, ColumnType};
+use crate::dialect::Dialect;
+use crate::table::Table;
+use crate::DdlError;
+
+/// DDL statement generator.
+///
+/// Generates SQL DDL statements (CREATE TABLE, ALTER TABLE, CREATE INDEX, etc.)
+/// tailored to the target database dialect.
+pub struct DdlGenerator {
+    dialect: Dialect,
+}
+
+impl DdlGenerator {
+    /// Create a new DDL generator for the given dialect.
+    pub fn new(dialect: Dialect) -> Self {
+        Self { dialect }
+    }
+
+    /// Generate a CREATE TABLE statement from a [`Table`] definition.
+    pub fn generate_create_table(&self, table: &Table) -> Result<String, DdlError> {
+        if table.name.is_empty() {
+            return Err(DdlError::InvalidTableName("(empty)".to_string()));
+        }
+
+        if table.columns.is_empty() {
+            return Err(DdlError::EmptyTable(table.name.clone()));
+        }
+
+        // Check for duplicate column names
+        let mut seen = std::collections::HashSet::new();
+        for col in &table.columns {
+            if !seen.insert(&col.name) {
+                return Err(DdlError::DuplicateColumn(col.name.clone()));
+            }
+        }
+
+        let mut sql = String::new();
+        sql.push_str(&format!("CREATE TABLE {} (\n", table.name));
+
+        let column_defs: Vec<String> = table
+            .columns
+            .iter()
+            .map(|col| self.format_column_def(col))
+            .collect();
+
+        sql.push_str(&column_defs.join(",\n"));
+        sql.push_str("\n)");
+
+        // Add dialect-specific extras
+        match self.dialect {
+            Dialect::MySQL => {
+                if let Some(ref comment) = table.comment {
+                    sql.push_str(&format!(" COMMENT='{}'", comment));
+                }
+            }
+            Dialect::PostgreSQL | Dialect::SQLite => {
+                // PostgreSQL uses separate COMMENT ON statement
+            }
+        }
+
+        sql.push(';');
+        Ok(sql)
+    }
+
+    /// Generate an ALTER TABLE ADD COLUMN statement.
+    pub fn generate_add_column(
+        &self,
+        table_name: &str,
+        column: &Column,
+    ) -> Result<String, DdlError> {
+        if table_name.is_empty() {
+            return Err(DdlError::InvalidTableName("(empty)".to_string()));
+        }
+
+        let col_def = self.format_column_def(column);
+        Ok(format!(
+            "ALTER TABLE {} ADD COLUMN {};",
+            table_name, col_def
+        ))
+    }
+
+    /// Generate a CREATE INDEX statement.
+    pub fn generate_create_index(
+        &self,
+        index_name: &str,
+        table_name: &str,
+        columns: &[&str],
+        unique: bool,
+    ) -> Result<String, DdlError> {
+        if index_name.is_empty() || table_name.is_empty() {
+            return Err(DdlError::InvalidTableName(
+                if index_name.is_empty() {
+                    "(empty index name)"
+                } else {
+                    "(empty table name)"
+                }
+                .to_string(),
+            ));
+        }
+
+        let unique_kw = if unique { "UNIQUE " } else { "" };
+        Ok(format!(
+            "CREATE {unique_kw}INDEX {index_name} ON {table_name} ({});",
+            columns.join(", ")
+        ))
+    }
+
+    /// Generate a statement to remove a table.
+    pub fn generate_drop_table(
+        &self,
+        table_name: &str,
+        if_exists: bool,
+    ) -> Result<String, DdlError> {
+        if table_name.is_empty() {
+            return Err(DdlError::InvalidTableName("(empty)".to_string()));
+        }
+
+        let if_exists_kw = if if_exists { "IF EXISTS " } else { "" };
+        Ok(format!("DROP TABLE {if_exists_kw}{table_name};"))
+    }
+
+    fn format_column_def(&self, col: &Column) -> String {
+        let type_str = self.map_column_type(&col.column_type);
+        let mut parts = vec![format!("  {} {}", col.name, type_str)];
+
+        if col.primary_key {
+            parts.push("PRIMARY KEY".to_string());
+            if self.dialect == Dialect::SQLite {
+                parts.push("AUTOINCREMENT".to_string());
+            }
+        }
+        if col.not_null {
+            parts.push("NOT NULL".to_string());
+        }
+        if col.unique {
+            parts.push("UNIQUE".to_string());
+        }
+        if let Some(ref default) = col.default {
+            parts.push(format!("DEFAULT {}", default));
+        }
+
+        parts.join(" ")
+    }
+
+    fn map_column_type(&self, col_type: &ColumnType) -> String {
+        match (col_type, self.dialect) {
+            (ColumnType::Boolean, Dialect::MySQL) => "TINYINT(1)".to_string(),
+            (ColumnType::Boolean, _) => "BOOLEAN".to_string(),
+
+            (ColumnType::Integer, Dialect::MySQL) => "INT".to_string(),
+            (ColumnType::Integer, _) => "INTEGER".to_string(),
+
+            (ColumnType::BigInt, _) => "BIGINT".to_string(),
+
+            (ColumnType::Float, _) => "FLOAT".to_string(),
+            (ColumnType::Double, Dialect::PostgreSQL) => "DOUBLE PRECISION".to_string(),
+            (ColumnType::Double, _) => "DOUBLE".to_string(),
+
+            (ColumnType::Char(n), _) => format!("CHAR({})", n),
+            (ColumnType::Varchar(n), _) => format!("VARCHAR({})", n),
+            (ColumnType::Text, _) => "TEXT".to_string(),
+            (ColumnType::Blob, Dialect::PostgreSQL) => "BYTEA".to_string(),
+            (ColumnType::Blob, _) => "BLOB".to_string(),
+
+            (ColumnType::Date, _) => "DATE".to_string(),
+            (ColumnType::DateTime, Dialect::PostgreSQL) => "TIMESTAMP".to_string(),
+            (ColumnType::DateTime, _) => "DATETIME".to_string(),
+            (ColumnType::Timestamp, Dialect::PostgreSQL) => "TIMESTAMPTZ".to_string(),
+            (ColumnType::Timestamp, _) => "TIMESTAMP".to_string(),
+
+            (ColumnType::Json, Dialect::SQLite) => "TEXT".to_string(),
+            (ColumnType::Json, Dialect::PostgreSQL) => "JSONB".to_string(),
+            (ColumnType::Json, Dialect::MySQL) => "JSON".to_string(),
+
+            (ColumnType::Uuid, Dialect::PostgreSQL) => "UUID".to_string(),
+            (ColumnType::Uuid, Dialect::MySQL) => "CHAR(36)".to_string(),
+            (ColumnType::Uuid, Dialect::SQLite) => "TEXT".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_table() -> Table {
+        Table::new("users")
+            .column(
+                Column::new("id", ColumnType::BigInt)
+                    .primary_key()
+                    .not_null(),
+            )
+            .column(Column::new("name", ColumnType::Varchar(255)).not_null())
+            .column(Column::new("email", ColumnType::Varchar(255)).unique())
+            .column(Column::new("active", ColumnType::Boolean).default("true"))
+    }
+
+    #[test]
+    fn create_table_postgresql() {
+        let ddl = DdlGenerator::new(Dialect::PostgreSQL);
+        let sql = ddl.generate_create_table(&sample_table()).unwrap();
+
+        assert!(sql.contains("CREATE TABLE users"));
+        assert!(sql.contains("BIGINT"));
+        assert!(sql.contains("VARCHAR(255)"));
+        assert!(sql.contains("BOOLEAN"));
+        assert!(sql.contains("PRIMARY KEY"));
+        assert!(sql.contains("NOT NULL"));
+        assert!(sql.contains("UNIQUE"));
+        assert!(sql.contains("DEFAULT true"));
+    }
+
+    #[test]
+    fn create_table_mysql_boolean_mapping() {
+        let ddl = DdlGenerator::new(Dialect::MySQL);
+        let table = Table::new("flags").column(Column::new("enabled", ColumnType::Boolean));
+        let sql = ddl.generate_create_table(&table).unwrap();
+
+        assert!(sql.contains("TINYINT(1)"));
+        assert!(!sql.contains("BOOLEAN"));
+    }
+
+    #[test]
+    fn create_table_empty_name_errors() {
+        let ddl = DdlGenerator::new(Dialect::SQLite);
+        let table = Table::new("").column(Column::new("id", ColumnType::Integer));
+        let result = ddl.generate_create_table(&table);
+        assert_eq!(
+            result,
+            Err(DdlError::InvalidTableName("(empty)".to_string()))
+        );
+    }
+
+    #[test]
+    fn create_table_no_columns_errors() {
+        let ddl = DdlGenerator::new(Dialect::PostgreSQL);
+        let table = Table::new("empty_table");
+        let result = ddl.generate_create_table(&table);
+        assert_eq!(result, Err(DdlError::EmptyTable("empty_table".to_string())));
+    }
+
+    #[test]
+    fn create_table_duplicate_column_errors() {
+        let ddl = DdlGenerator::new(Dialect::PostgreSQL);
+        let table = Table::new("dup")
+            .column(Column::new("id", ColumnType::Integer))
+            .column(Column::new("id", ColumnType::Text));
+        let result = ddl.generate_create_table(&table);
+        assert_eq!(result, Err(DdlError::DuplicateColumn("id".to_string())));
+    }
+
+    #[test]
+    fn add_column_statement() {
+        let ddl = DdlGenerator::new(Dialect::PostgreSQL);
+        let col = Column::new("age", ColumnType::Integer)
+            .not_null()
+            .default("0");
+        let sql = ddl.generate_add_column("users", &col).unwrap();
+
+        assert!(sql.contains("ALTER TABLE users ADD COLUMN"));
+        assert!(sql.contains("INTEGER"));
+        assert!(sql.contains("NOT NULL"));
+        assert!(sql.contains("DEFAULT 0"));
+    }
+
+    #[test]
+    fn create_index_statement() {
+        let ddl = DdlGenerator::new(Dialect::PostgreSQL);
+        let sql = ddl
+            .generate_create_index("idx_users_email", "users", &["email"], true)
+            .unwrap();
+
+        assert!(sql.contains("CREATE UNIQUE INDEX"));
+        assert!(sql.contains("idx_users_email"));
+        assert!(sql.contains("ON users"));
+    }
+
+    #[test]
+    fn drop_table_if_exists() {
+        let ddl = DdlGenerator::new(Dialect::SQLite);
+        let sql = ddl.generate_drop_table("old_table", true).unwrap();
+        assert_eq!(sql, "DROP TABLE IF EXISTS old_table;");
+    }
+
+    #[test]
+    fn sqlite_autoincrement() {
+        let ddl = DdlGenerator::new(Dialect::SQLite);
+        let table = Table::new("items").column(
+            Column::new("id", ColumnType::Integer)
+                .primary_key()
+                .not_null(),
+        );
+        let sql = ddl.generate_create_table(&table).unwrap();
+
+        assert!(sql.contains("AUTOINCREMENT"));
+    }
+
+    #[test]
+    fn postgresql_blob_is_bytea() {
+        let ddl = DdlGenerator::new(Dialect::PostgreSQL);
+        let table = Table::new("files").column(Column::new("data", ColumnType::Blob).not_null());
+        let sql = ddl.generate_create_table(&table).unwrap();
+
+        assert!(sql.contains("BYTEA"));
+        assert!(!sql.contains("BLOB"));
+    }
+
+    #[test]
+    fn mysql_comment_support() {
+        let ddl = DdlGenerator::new(Dialect::MySQL);
+        let table = Table::new("users")
+            .column(Column::new("id", ColumnType::BigInt).primary_key())
+            .comment("User accounts");
+        let sql = ddl.generate_create_table(&table).unwrap();
+
+        assert!(sql.contains("COMMENT='User accounts'"));
+    }
+
+    #[test]
+    fn uuid_dialect_mapping() {
+        let ddl = DdlGenerator::new(Dialect::PostgreSQL);
+        let table = Table::new("t").column(Column::new("uuid_col", ColumnType::Uuid));
+        let pg_sql = ddl.generate_create_table(&table).unwrap();
+        assert!(pg_sql.contains("UUID"));
+
+        let ddl = DdlGenerator::new(Dialect::MySQL);
+        let mysql_sql = ddl.generate_create_table(&table).unwrap();
+        assert!(mysql_sql.contains("CHAR(36)"));
+
+        let ddl = DdlGenerator::new(Dialect::SQLite);
+        let sqlite_sql = ddl.generate_create_table(&table).unwrap();
+        assert!(sqlite_sql.contains("TEXT"));
+    }
+
+    #[test]
+    fn json_dialect_mapping() {
+        let ddl = DdlGenerator::new(Dialect::PostgreSQL);
+        let t = Table::new("j").column(Column::new("data", ColumnType::Json));
+        assert!(ddl.generate_create_table(&t).unwrap().contains("JSONB"));
+
+        let ddl = DdlGenerator::new(Dialect::MySQL);
+        assert!(ddl.generate_create_table(&t).unwrap().contains("JSON"));
+
+        let ddl = DdlGenerator::new(Dialect::SQLite);
+        assert!(ddl.generate_create_table(&t).unwrap().contains("TEXT"));
+    }
+}

--- a/crates/data/addzero-ddl-generator/src/lib.rs
+++ b/crates/data/addzero-ddl-generator/src/lib.rs
@@ -1,0 +1,48 @@
+//! DDL statement generator supporting multiple database dialects.
+//!
+//! Provides a type-safe API for generating `CREATE TABLE`, `ALTER TABLE`,
+//! `CREATE INDEX`, and other DDL statements across different SQL dialects
+//! (MySQL, PostgreSQL, SQLite).
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! use addzero_ddl_generator::{DdlGenerator, Table, Column, ColumnType, Dialect};
+//!
+//! let table = Table::new("users")
+//!     .column(Column::new("id", ColumnType::BigInt).primary_key().not_null())
+//!     .column(Column::new("name", ColumnType::Varchar(255)).not_null())
+//!     .column(Column::new("email", ColumnType::Varchar(255)).unique());
+//!
+//! let ddl = DdlGenerator::new(Dialect::PostgreSQL).generate_create_table(&table).unwrap();
+//! assert!(ddl.contains("CREATE TABLE"));
+//! assert!(ddl.contains("users"));
+//! ```
+
+use thiserror::Error;
+
+mod column;
+mod dialect;
+mod generator;
+mod table;
+
+pub use column::{Column, ColumnType};
+pub use dialect::Dialect;
+pub use generator::DdlGenerator;
+pub use table::Table;
+
+/// Errors that can occur during DDL generation.
+#[derive(Debug, Error, PartialEq)]
+pub enum DdlError {
+    /// The table name is empty or invalid.
+    #[error("invalid table name: {0}")]
+    InvalidTableName(String),
+
+    /// The table has no columns defined.
+    #[error("table '{0}' has no columns")]
+    EmptyTable(String),
+
+    /// Duplicate column name detected.
+    #[error("duplicate column name: '{0}'")]
+    DuplicateColumn(String),
+}

--- a/crates/data/addzero-ddl-generator/src/table.rs
+++ b/crates/data/addzero-ddl-generator/src/table.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+
+use crate::column::Column;
+
+/// Represents a database table definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Table {
+    /// Table name.
+    pub name: String,
+    /// Columns in the table.
+    pub columns: Vec<Column>,
+    /// Optional table comment.
+    pub comment: Option<String>,
+}
+
+impl Table {
+    /// Create a new table with the given name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            columns: Vec::new(),
+            comment: None,
+        }
+    }
+
+    /// Add a column to this table.
+    pub fn column(mut self, col: Column) -> Self {
+        self.columns.push(col);
+        self
+    }
+
+    /// Add a table comment.
+    pub fn comment(mut self, text: impl Into<String>) -> Self {
+        self.comment = Some(text.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::column::ColumnType;
+
+    #[test]
+    fn table_builder() {
+        let table = Table::new("users")
+            .column(Column::new("id", ColumnType::BigInt).primary_key())
+            .column(Column::new("name", ColumnType::Varchar(100)))
+            .comment("User accounts table");
+
+        assert_eq!(table.name, "users");
+        assert_eq!(table.columns.len(), 2);
+        assert!(table.columns[0].primary_key);
+        assert_eq!(table.comment.as_deref(), Some("User accounts table"));
+    }
+
+    #[test]
+    fn table_serialization_roundtrip() {
+        let table = Table::new("orders")
+            .column(Column::new("id", ColumnType::BigInt).primary_key())
+            .column(Column::new("total", ColumnType::Float).not_null());
+
+        let json = serde_json::to_string(&table).unwrap();
+        let deserialized: Table = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.name, "orders");
+        assert_eq!(deserialized.columns.len(), 2);
+    }
+}


### PR DESCRIPTION
Closes #22

## Test Report
- cargo test: 18 passed, 0 failed (+ 1 doctest)
- cargo clippy: 0 warnings

## Implementation
- addzero-ddl-generator crate: DDL statement generation
- Supports MySQL, PostgreSQL, SQLite dialects
- CREATE TABLE, ALTER TABLE ADD COLUMN, CREATE INDEX
- Type mapping differences across dialects
- Autoincrement, Comment, IF EXISTS support