### PR TITLE
fix: enforce workspace-level forbid(unsafe_code) + clippy fixes (#36)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,50 +1974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "msc-aio"
-version = "0.1.0"
-dependencies = [
- "addzero-agent-runtime-contract",
- "addzero-ai-agent",
- "addzero-assets",
- "addzero-cli-market-contract",
- "addzero-knowledge",
- "addzero-persistence",
- "addzero-rustfs",
- "addzero-skills",
- "addzero-software-catalog",
- "anyhow",
- "axum",
- "base64",
- "blake3",
- "chrono",
- "dioxus",
- "dioxus-components",
- "dioxus-free-icons",
- "futures-util",
- "getrandom 0.3.4",
- "hmac",
- "js-sys",
- "log",
- "quick-xml",
- "regex",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sha2",
- "shlex",
- "sqlx",
- "thiserror 2.0.18",
- "tokio",
- "tower-http",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "zip",
-]
-
-[[package]]
 name = "dioxus-asset-resolver"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4714,6 +4670,50 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "msc-aio"
+version = "0.1.0"
+dependencies = [
+ "addzero-agent-runtime-contract",
+ "addzero-ai-agent",
+ "addzero-assets",
+ "addzero-cli-market-contract",
+ "addzero-knowledge",
+ "addzero-persistence",
+ "addzero-rustfs",
+ "addzero-skills",
+ "addzero-software-catalog",
+ "anyhow",
+ "axum",
+ "base64",
+ "blake3",
+ "chrono",
+ "dioxus",
+ "dioxus-components",
+ "dioxus-free-icons",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hmac",
+ "js-sys",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "shlex",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-http",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 resolver = "2"
 members = [
-    "apps/*",
+    "apps/msc-aio",
+    "apps/remote-desktop/*",
     "crates/api/*",
     "crates/config/*",
     "crates/core/*",

--- a/apps/msc-aio/src/app.rs
+++ b/apps/msc-aio/src/app.rs
@@ -132,7 +132,7 @@ fn Files() -> Element {
 pub fn AppLayout() -> Element {
     let auth = use_context::<AuthSession>();
     let nav = use_navigator();
-    let redirect_nav = nav.clone();
+    let redirect_nav = nav;
 
     use_effect(move || {
         if *auth.ready.read() && !*auth.logged_in.read() {

--- a/apps/msc-aio/src/bin/admin_api.rs
+++ b/apps/msc-aio/src/bin/admin_api.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    dioxus_admin::server::run_api_server().await
+    msc_aio::server::run_api_server().await
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/apps/msc-aio/src/main.rs
+++ b/apps/msc-aio/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    dioxus::launch(dioxus_admin::app::App);
+    dioxus::launch(msc_aio::app::App);
 }

--- a/apps/msc-aio/src/scenes/auth.rs
+++ b/apps/msc-aio/src/scenes/auth.rs
@@ -37,7 +37,7 @@ pub fn LoginPage() -> Element {
     } else {
         "签名 Cookie 单管理员会话。".to_string()
     };
-    let redirect_nav = nav.clone();
+    let redirect_nav = nav;
 
     use_effect(move || {
         if *auth.ready.read() && *auth.logged_in.read() {

--- a/crates/core/addzero-dict-macros/src/lib.rs
+++ b/crates/core/addzero-dict-macros/src/lib.rs
@@ -278,6 +278,7 @@ fn resolve_include_path(path_text: &str) -> std::result::Result<PathBuf, String>
     Ok(normalize_path(base_dir.join(candidate)))
 }
 
+#[allow(clippy::incompatible_msrv)]
 fn resolve_call_site_file() -> std::result::Result<PathBuf, String> {
     let span = proc_macro::Span::call_site();
     if let Some(path) = span.local_file() {

--- a/crates/data/addzero-assets/src/pg_repo.rs
+++ b/crates/data/addzero-assets/src/pg_repo.rs
@@ -302,7 +302,7 @@ impl PgRepo {
 fn model_to_asset(row: asset::Model) -> Asset {
     Asset {
         id: row.id,
-        kind: AssetKind::from_str(&row.kind),
+        kind: AssetKind::from_db_value(&row.kind),
         title: row.title,
         body: row.body,
         tags: row.tags,
@@ -329,7 +329,7 @@ fn model_to_edge(row: asset_edge::Model) -> AssetEdge {
 
 fn model_to_provider(row: ai_model_provider::Model) -> AiModelProvider {
     AiModelProvider {
-        provider: AiProviderKind::from_str(&row.provider),
+        provider: AiProviderKind::from_db_value(&row.provider),
         default_model: row.default_model,
         enabled: row.enabled,
         key_id: row.key_id,
@@ -342,9 +342,9 @@ fn model_to_prompt(row: ai_prompt_button::Model) -> AiPromptButton {
     AiPromptButton {
         id: row.id,
         label: row.label,
-        target_kind: AssetKind::from_str(&row.target_kind),
+        target_kind: AssetKind::from_db_value(&row.target_kind),
         prompt_template: row.prompt_template,
-        provider: AiProviderKind::from_str(&row.provider),
+        provider: AiProviderKind::from_db_value(&row.provider),
         model: row.model,
         enabled: row.enabled,
         updated_at: row.updated_at,

--- a/crates/data/addzero-assets/src/types.rs
+++ b/crates/data/addzero-assets/src/types.rs
@@ -24,7 +24,7 @@ impl AssetKind {
         }
     }
 
-    pub fn from_str(value: &str) -> Self {
+    pub fn from_db_value(value: &str) -> Self {
         match value {
             "capture" => Self::Capture,
             "skill" => Self::Skill,
@@ -122,7 +122,7 @@ impl AiProviderKind {
         }
     }
 
-    pub fn from_str(value: &str) -> Self {
+    pub fn from_db_value(value: &str) -> Self {
         match value {
             "anthropic" => Self::Anthropic,
             "gemini" => Self::Gemini,


### PR DESCRIPTION
Fixes #36. Ensure all crates inherit workspace lints and fix clippy warnings.