### PR TITLE
fix: replace lock expect with graceful recovery (#38)

### DIFF
--- a/crates/core/addzero-log/src/lib.rs
+++ b/crates/core/addzero-log/src/lib.rs
@@ -12,20 +12,20 @@ where
     T: 'static,
 {
     let type_id = TypeId::of::<T>();
-    if let Some(target) = logger_map()
-        .read()
-        .expect("logger cache should be readable")
-        .get(&type_id)
-        .copied()
-    {
+    let read_guard = match logger_map().read() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if let Some(target) = read_guard.get(&type_id).copied() {
         return target;
     }
 
     let target = type_name::<T>();
-    logger_map()
-        .write()
-        .expect("logger cache should be writable")
-        .insert(type_id, target);
+    let mut write_guard = match logger_map().write() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    write_guard.insert(type_id, target);
     target
 }
 

--- a/crates/core/addzero-reflection/src/metainfo.rs
+++ b/crates/core/addzero-reflection/src/metainfo.rs
@@ -1,4 +1,11 @@
 use regex::Regex;
+use std::sync::LazyLock;
+
+static TABLE_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| match Regex::new(r"(?i)\bfrom\s+([a-zA-Z0-9_]+)") {
+        Ok(regex) => regex,
+        Err(error) => panic!("table extraction regex should compile: {error}"),
+    });
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldInfoSimple {
@@ -106,9 +113,7 @@ pub fn get_simple_field_info_str<T: MetaInfo>() -> String {
 }
 
 pub fn extract_table_name(sql: impl AsRef<str>) -> Option<String> {
-    let regex =
-        Regex::new(r"(?i)\bfrom\s+([a-zA-Z0-9_]+)").expect("table extraction regex should compile");
-    regex
+    TABLE_NAME_REGEX
         .captures(sql.as_ref())
         .and_then(|captures| captures.get(1).map(|table| table.as_str().to_owned()))
 }

--- a/crates/network/addzero-email/src/lib.rs
+++ b/crates/network/addzero-email/src/lib.rs
@@ -232,23 +232,25 @@ static DEFAULT_SENDER: OnceLock<RwLock<Option<Arc<dyn EmailSender>>>> = OnceLock
 
 pub fn set_default_sender(sender: Arc<dyn EmailSender>) {
     let lock = DEFAULT_SENDER.get_or_init(|| RwLock::new(None));
-    *lock
-        .write()
-        .expect("email sender lock should not be poisoned") = Some(sender);
+    *match lock.write() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    } = Some(sender);
 }
 
 pub fn clear_default_sender() {
     let lock = DEFAULT_SENDER.get_or_init(|| RwLock::new(None));
-    *lock
-        .write()
-        .expect("email sender lock should not be poisoned") = None;
+    *match lock.write() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    } = None;
 }
 
 pub fn send(message: &EmailMessage) -> Result<(), EmailError> {
     let sender = DEFAULT_SENDER
         .get_or_init(|| RwLock::new(None))
         .read()
-        .expect("email sender lock should not be poisoned")
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone()
         .ok_or(EmailError::MissingDefaultSender)?;
     sender.send(message)


### PR DESCRIPTION
Fixes #38. Replace .expect() on RwLock/Mutex with poisoned.into_inner(), and Regex::new().expect() with LazyLock.