### PR TITLE
feat(lowcode): #74 crate 骨架 + workspace 集成 + axum 路由挂载

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addzero-lowcode"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "rhai",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "addzero-math"
 version = "0.1.0"
 dependencies = [
@@ -714,6 +729,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1452,6 +1481,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const-serialize"
@@ -5033,6 +5082,9 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -5450,6 +5502,12 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-pty"
@@ -6067,6 +6125,34 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rhai"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
+dependencies = [
+ "ahash",
+ "bitflags 2.11.1",
+ "num-traits",
+ "once_cell",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+ "thin-vec",
+ "web-time",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4322a2a4e8cf30771dd9f27f7f37ca9ac8fe812dddd811096a98483080dabe6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6971,6 +7057,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7539,6 +7636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7616,6 +7719,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/storage/*",
     "crates/text/*",
     "crates/ui/*",
+    "crates/apps/addzero-lowcode",
 ]
 exclude = ["apps/remote-desktop"]
 
@@ -67,6 +68,7 @@ sea-orm = { version = "1.1.20", default-features = false, features = ["macros", 
 sea-orm-migration = { version = "1.1.20", default-features = false, features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 futures-util = "0.3.31"
 quinn = { version = "0.11.9", default-features = false, features = ["runtime-tokio", "rustls"] }
+axum = { version = "0.8.6", features = ["http1", "json", "tokio", "ws"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/apps/addzero-lowcode/Cargo.toml
+++ b/crates/apps/addzero-lowcode/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "addzero-lowcode"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+axum = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+sqlx = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+rhai = "1.20"
+
+[lints]
+workspace = true

--- a/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
+++ b/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
@@ -1,0 +1,50 @@
+-- Lowcode service — initial schema
+-- Tables follow the all-in-pg convention.
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- layouts: top-level container of component nodes
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_layouts (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL,
+    nodes       JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- component_defs: registered component type metadata
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_component_defs (
+    type_name    TEXT PRIMARY KEY,
+    props_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
+    category     TEXT NOT NULL DEFAULT 'general',
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- templates: reusable layout templates
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_templates (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name       TEXT NOT NULL,
+    layout     JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- event_bindings: bindings that connect component events to handlers
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_event_bindings (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    layout_id    UUID NOT NULL REFERENCES lowcode_layouts(id) ON DELETE CASCADE,
+    node_id      UUID NOT NULL,
+    event_name   TEXT NOT NULL,
+    handler      JSONB NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_bindings_layout
+    ON lowcode_event_bindings(layout_id);

--- a/crates/apps/addzero-lowcode/src/editor.rs
+++ b/crates/apps/addzero-lowcode/src/editor.rs
@@ -1,0 +1,14 @@
+/// Canvas editor operations (skeleton — to be implemented in #78).
+pub struct CanvasEditor;
+
+impl CanvasEditor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CanvasEditor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/events.rs
+++ b/crates/apps/addzero-lowcode/src/events.rs
@@ -1,0 +1,15 @@
+/// Event system and handler registry (skeleton — to be implemented in #79).
+#[derive(Clone)]
+pub struct HandlerRegistry;
+
+impl HandlerRegistry {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HandlerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/grid.rs
+++ b/crates/apps/addzero-lowcode/src/grid.rs
@@ -1,0 +1,14 @@
+/// Grid-based layout engine (skeleton — to be implemented in #76).
+pub struct GridEngine;
+
+impl GridEngine {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for GridEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/lib.rs
+++ b/crates/apps/addzero-lowcode/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod schema;
+pub mod grid;
+pub mod registry;
+pub mod editor;
+pub mod events;
+pub mod scripting;
+pub mod render;
+pub mod template;
+pub mod repo;
+pub mod router;
+pub mod state;
+
+pub use router::lowcode_router;
+pub use state::LowcodeState;

--- a/crates/apps/addzero-lowcode/src/registry.rs
+++ b/crates/apps/addzero-lowcode/src/registry.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+use crate::schema::ComponentDef;
+
+/// In-memory component type registry (skeleton — to be fleshed out in #77).
+#[derive(Clone)]
+pub struct ComponentRegistry {
+    components: HashMap<String, ComponentDef>,
+}
+
+impl ComponentRegistry {
+    pub fn new() -> Self {
+        Self {
+            components: HashMap::new(),
+        }
+    }
+
+    /// Register a new component definition.
+    pub fn register(&mut self, def: ComponentDef) {
+        self.components.insert(def.type_name.clone(), def);
+    }
+
+    /// Look up a component by type name.
+    pub fn get(&self, type_name: &str) -> Option<&ComponentDef> {
+        self.components.get(type_name)
+    }
+
+    /// List all registered component definitions.
+    pub fn list(&self) -> Vec<&ComponentDef> {
+        self.components.values().collect()
+    }
+}
+
+impl Default for ComponentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/render.rs
+++ b/crates/apps/addzero-lowcode/src/render.rs
@@ -1,0 +1,28 @@
+/// Render pipeline — converts a layout tree into output (skeleton — to be implemented in #81).
+
+use crate::schema::Layout;
+
+/// Errors that can occur during rendering.
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    #[error("layout not found: {0}")]
+    LayoutNotFound(uuid::Uuid),
+    #[error("unsupported component type: {0}")]
+    UnsupportedComponent(String),
+    #[error("render pipeline error: {0}")]
+    Pipeline(String),
+}
+
+/// Placeholder render result.
+#[derive(Debug, Clone)]
+pub struct RenderOutput {
+    pub html: String,
+}
+
+/// Renders a layout into a preview-ready output.
+///
+/// The actual rendering logic will be fleshed out in #81.
+pub fn render(layout: &Layout) -> Result<RenderOutput, RenderError> {
+    let _ = layout;
+    todo!("render pipeline — will be implemented in #81")
+}

--- a/crates/apps/addzero-lowcode/src/repo.rs
+++ b/crates/apps/addzero-lowcode/src/repo.rs
@@ -1,0 +1,51 @@
+/// PG repository for lowcode layouts (skeleton — to be fleshed out in subsequent issues).
+
+use uuid::Uuid;
+
+use crate::schema::Layout;
+
+/// Errors from layout repository operations.
+#[derive(Debug, thiserror::Error)]
+pub enum RepoError {
+    #[error("layout not found: {0}")]
+    NotFound(Uuid),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+/// Layout repository backed by PostgreSQL (skeleton).
+///
+/// The actual query implementations will be added alongside issues #75–#81.
+pub struct LayoutRepo;
+
+impl LayoutRepo {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn create(&self, _layout: &Layout) -> Result<Layout, RepoError> {
+        todo!("layout create — will be implemented in #75")
+    }
+
+    pub async fn get(&self, _id: Uuid) -> Result<Layout, RepoError> {
+        todo!("layout get — will be implemented in #75")
+    }
+
+    pub async fn list(&self) -> Result<Vec<Layout>, RepoError> {
+        todo!("layout list — will be implemented in #75")
+    }
+
+    pub async fn update(&self, _layout: &Layout) -> Result<Layout, RepoError> {
+        todo!("layout update — will be implemented in #75")
+    }
+
+    pub async fn delete(&self, _id: Uuid) -> Result<(), RepoError> {
+        todo!("layout delete — will be implemented in #75")
+    }
+}
+
+impl Default for LayoutRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/router.rs
+++ b/crates/apps/addzero-lowcode/src/router.rs
@@ -1,0 +1,161 @@
+/// Axum router for the lowcode service.
+
+use axum::{
+    Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, patch, post},
+};
+use uuid::Uuid;
+
+use crate::state::LowcodeState;
+
+// ---------------------------------------------------------------------------
+// Layout CRUD handlers (skeleton — handlers are todo!())
+// ---------------------------------------------------------------------------
+
+async fn create_layout(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "create_layout")
+}
+
+async fn list_layouts(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_layouts")
+}
+
+async fn get_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "get_layout")
+}
+
+async fn update_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_layout")
+}
+
+async fn delete_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_layout")
+}
+
+// ---------------------------------------------------------------------------
+// Canvas / node operations (skeleton — #78)
+// ---------------------------------------------------------------------------
+
+async fn place_component(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "place_component")
+}
+
+async fn update_props(
+    _state: State<LowcodeState>,
+    _path: Path<(Uuid, String)>,
+) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_props")
+}
+
+async fn delete_component(
+    _state: State<LowcodeState>,
+    _path: Path<(Uuid, String)>,
+) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_component")
+}
+
+// ---------------------------------------------------------------------------
+// Preview & render (skeleton — #81)
+// ---------------------------------------------------------------------------
+
+async fn preview_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "preview_layout")
+}
+
+async fn render_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "render_layout")
+}
+
+// ---------------------------------------------------------------------------
+// Event handling (skeleton — #79)
+// ---------------------------------------------------------------------------
+
+async fn handle_event(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "handle_event")
+}
+
+// ---------------------------------------------------------------------------
+// Scripting (skeleton — #80)
+// ---------------------------------------------------------------------------
+
+async fn validate_script(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "validate_script")
+}
+
+// ---------------------------------------------------------------------------
+// Template CRUD (skeleton — #81)
+// ---------------------------------------------------------------------------
+
+async fn create_template(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "create_template")
+}
+
+async fn list_templates(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_templates")
+}
+
+async fn get_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "get_template")
+}
+
+async fn update_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_template")
+}
+
+async fn delete_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_template")
+}
+
+// ---------------------------------------------------------------------------
+// Component registry (skeleton — #77)
+// ---------------------------------------------------------------------------
+
+async fn list_components(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_components")
+}
+
+async fn register_component(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "register_component")
+}
+
+// ---------------------------------------------------------------------------
+// Router assembly
+// ---------------------------------------------------------------------------
+
+/// Builds the full lowcode API router.
+pub fn lowcode_router(state: LowcodeState) -> Router {
+    Router::new()
+        .route("/api/lowcode/layout", post(create_layout).get(list_layouts))
+        .route(
+            "/api/lowcode/layout/{id}",
+            get(get_layout).put(update_layout).delete(delete_layout),
+        )
+        .route(
+            "/api/lowcode/layout/{id}/node",
+            post(place_component),
+        )
+        .route(
+            "/api/lowcode/layout/{id}/node/{*path}",
+            patch(update_props).delete(delete_component),
+        )
+        .route("/api/lowcode/layout/{id}/preview", get(preview_layout))
+        .route("/api/lowcode/layout/{id}/render", get(render_layout))
+        .route("/api/lowcode/event", post(handle_event))
+        .route("/api/lowcode/script/validate", post(validate_script))
+        .route(
+            "/api/lowcode/template",
+            post(create_template).get(list_templates),
+        )
+        .route(
+            "/api/lowcode/template/{id}",
+            get(get_template).put(update_template).delete(delete_template),
+        )
+        .route(
+            "/api/lowcode/component",
+            get(list_components).post(register_component),
+        )
+        .with_state(state)
+}

--- a/crates/apps/addzero-lowcode/src/schema.rs
+++ b/crates/apps/addzero-lowcode/src/schema.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A lowcode layout — the top-level container of component nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Layout {
+    pub id: Uuid,
+    pub name: String,
+    pub nodes: Vec<Node>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A single component node in the layout tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    pub id: Uuid,
+    pub component_type: String,
+    pub props: serde_json::Value,
+    pub children: Vec<Node>,
+    pub grid_pos: Option<GridPos>,
+}
+
+/// Position within a CSS Grid layout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GridPos {
+    pub col: u32,
+    pub row: u32,
+    pub col_span: u32,
+    pub row_span: u32,
+}
+
+/// Binds a component event to an action handler.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventBinding {
+    pub event_name: String,
+    pub handler: EventHandler,
+}
+
+/// The action to perform when an event fires.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
+pub enum EventHandler {
+    Navigate(String),
+    Script(String),
+    Callback(String),
+}
+
+/// Metadata for a registered component type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentDef {
+    pub type_name: String,
+    pub props_schema: serde_json::Value,
+    pub category: String,
+}
+
+/// A reusable layout template.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Template {
+    pub id: Uuid,
+    pub name: String,
+    pub layout: Layout,
+    pub created_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_grid_pos_roundtrip() {
+        let pos = GridPos {
+            col: 1,
+            row: 2,
+            col_span: 3,
+            row_span: 4,
+        };
+        let json = serde_json::to_string(&pos).unwrap();
+        let back: GridPos = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.col, 1);
+        assert_eq!(back.row_span, 4);
+    }
+}

--- a/crates/apps/addzero-lowcode/src/scripting.rs
+++ b/crates/apps/addzero-lowcode/src/scripting.rs
@@ -1,0 +1,15 @@
+/// Rhai scripting engine (skeleton — to be implemented in #80).
+#[derive(Clone)]
+pub struct ScriptEngine;
+
+impl ScriptEngine {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ScriptEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/state.rs
+++ b/crates/apps/addzero-lowcode/src/state.rs
@@ -1,0 +1,27 @@
+use sqlx::PgPool;
+
+use crate::events::HandlerRegistry;
+use crate::registry::ComponentRegistry;
+use crate::scripting::ScriptEngine;
+
+/// Shared application state for the lowcode service.
+///
+/// Houses the PG pool plus in-memory registries and engines.
+#[derive(Clone)]
+pub struct LowcodeState {
+    pub db: PgPool,
+    pub registry: ComponentRegistry,
+    pub script_engine: ScriptEngine,
+    pub handler_registry: HandlerRegistry,
+}
+
+impl LowcodeState {
+    pub fn new(db: PgPool) -> Self {
+        Self {
+            db,
+            registry: ComponentRegistry::new(),
+            script_engine: ScriptEngine::new(),
+            handler_registry: HandlerRegistry::new(),
+        }
+    }
+}

--- a/crates/apps/addzero-lowcode/src/template.rs
+++ b/crates/apps/addzero-lowcode/src/template.rs
@@ -1,0 +1,53 @@
+/// Template management — save/load reusable layout templates (skeleton — to be fleshed out in #81).
+
+use uuid::Uuid;
+
+use crate::schema::Template;
+
+/// Errors from template operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TemplateError {
+    #[error("template not found: {0}")]
+    NotFound(Uuid),
+    #[error("template validation failed: {0}")]
+    ValidationFailed(String),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+/// Template repository backed by PostgreSQL (skeleton).
+///
+/// The actual query implementations will be added alongside #81.
+pub struct TemplateRepo;
+
+impl TemplateRepo {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn create(&self, _tpl: &Template) -> Result<Template, TemplateError> {
+        todo!("template create — will be implemented in #81")
+    }
+
+    pub async fn get(&self, _id: Uuid) -> Result<Template, TemplateError> {
+        todo!("template get — will be implemented in #81")
+    }
+
+    pub async fn list(&self) -> Result<Vec<Template>, TemplateError> {
+        todo!("template list — will be implemented in #81")
+    }
+
+    pub async fn update(&self, _tpl: &Template) -> Result<Template, TemplateError> {
+        todo!("template update — will be implemented in #81")
+    }
+
+    pub async fn delete(&self, _id: Uuid) -> Result<(), TemplateError> {
+        todo!("template delete — will be implemented in #81")
+    }
+}
+
+impl Default for TemplateRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## 概述

创建 `addzero-lowcode` crate 骨架，接入 workspace 依赖管理，定义 axum 路由层，将所有子模块串联为可运行的服务。

## 变更内容

- 创建 `crates/apps/addzero-lowcode/` crate
- **Schema**：Layout / Node / GridPos / EventBinding / ComponentDef / Template 三层数据模型
- **骨架模块**（全部使用 todo!() / 501 桩函数，供后续 issue 实现）：
  - `grid.rs` — 栅格布局引擎（#76）
  - `registry.rs` — 组件注册表（#77）
  - `editor.rs` — 画布编辑器（#78）
  - `events.rs` — 事件系统（#79）
  - `scripting.rs` — Rhai 脚本引擎（#80）
  - `render.rs` — 渲染管线（#81）
  - `template.rs` — 模板管理（#81）
  - `repo.rs` — PG layout repository
  - `router.rs` — axum Router 完整路由表
  - `state.rs` — LowcodeState（PgPool + ComponentRegistry + ScriptEngine + HandlerRegistry）
- **Migration**：`migrations/001_init_lowcode.sql`（lowcode_layouts / lowcode_component_defs / lowcode_templates / lowcode_event_bindings）
- workspace `Cargo.toml` 已加入 members

## 验收

- [x] `cargo check -p addzero-lowcode` 通过
- [x] 所有 `pub mod` 声明 + 模块文件就位
- [x] Router 编译通过（handler 函数全部返回 501 NOT_IMPLEMENTED）
- [x] LowcodeState 定义（PG pool、ComponentRegistry、ScriptEngine、HandlerRegistry）
- [x] SQL migration 文件就位
- [x] workspace Cargo.toml 已加入 members
- [x] `cargo test -p addzero-lowcode` 1 passed

Closes #74