### PR TITLE
fix: replace SystemTime with monotonic Instant in polling loops (#88)

### DIFF
--- a/crates/music/addzero-music/src/lib.rs
+++ b/crates/music/addzero-music/src/lib.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant};
 use thiserror::Error;
 
 pub type MusicResult<T> = Result<T, MusicError>;
@@ -718,7 +718,7 @@ impl SunoApi {
         F: FnMut(Option<&str>),
     {
         let task_id = task_id.as_ref().trim().to_owned();
-        let started = SystemTime::now();
+        let started = Instant::now();
 
         loop {
             let task = self.fetch_task(task_id.as_str())?;
@@ -737,7 +737,7 @@ impl SunoApi {
                     )));
                 }
                 _ => {
-                    if started.elapsed().unwrap_or_default() >= max_wait {
+                    if started.elapsed() >= max_wait {
                         return Err(MusicError::InvalidResponse(format!(
                             "suno task `{task_id}` timed out after {:?}",
                             max_wait
@@ -772,7 +772,7 @@ impl SunoApi {
         S: Into<String>,
     {
         let task_ids = task_ids.into_iter().map(Into::into).collect::<Vec<_>>();
-        let started = SystemTime::now();
+        let started = Instant::now();
 
         loop {
             let tasks = self.batch_fetch_tasks(task_ids.clone())?;
@@ -794,7 +794,7 @@ impl SunoApi {
                         .unwrap_or_else(|| "unknown error".to_owned())
                 )));
             }
-            if started.elapsed().unwrap_or_default() >= max_wait {
+            if started.elapsed() >= max_wait {
                 return Err(MusicError::InvalidResponse(format!(
                     "suno tasks timed out after {:?}",
                     max_wait

--- a/crates/network/addzero-email/src/temp_mail.rs
+++ b/crates/network/addzero-email/src/temp_mail.rs
@@ -9,7 +9,7 @@ use serde_json::{Value, json};
 use std::collections::{BTreeMap, HashSet};
 use std::ops::Deref;
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 pub type EmailResult<T> = Result<T, EmailError>;
@@ -327,14 +327,14 @@ impl TempMailApi {
     ) -> EmailResult<TempMailMessageDetail> {
         let token = trim_required(token.as_ref(), "token")?;
         validate_poll_durations(max_wait, poll_interval)?;
-        let started = SystemTime::now();
+        let started = Instant::now();
 
         loop {
             if let Some(summary) = self.list_messages(token, 1)?.into_iter().next() {
                 return self.get_message(token, summary.id);
             }
 
-            if started.elapsed().unwrap_or_default() >= max_wait {
+            if started.elapsed() >= max_wait {
                 return Err(EmailError::InvalidResponse(format!(
                     "timed out waiting for message after {:?}",
                     max_wait
@@ -353,7 +353,7 @@ impl TempMailApi {
     ) -> EmailResult<TempMailVerificationCode> {
         let token = trim_required(token.as_ref(), "token")?;
         validate_poll_durations(max_wait, poll_interval)?;
-        let started = SystemTime::now();
+        let started = Instant::now();
         let mut inspected_ids = HashSet::new();
 
         loop {
@@ -374,7 +374,7 @@ impl TempMailApi {
                 }
             }
 
-            if started.elapsed().unwrap_or_default() >= max_wait {
+            if started.elapsed() >= max_wait {
                 return Err(EmailError::InvalidResponse(format!(
                     "timed out waiting for verification code after {:?}",
                     max_wait


### PR DESCRIPTION
Closes #88

## Problem

Multiple polling functions in `addzero-music` and `addzero-email` used `SystemTime::now()` + `.elapsed()` to measure wait duration. `SystemTime` is a non-monotonic wall clock affected by NTP step corrections, manual time adjustments, VM migration clock fixes, and leap seconds.

Two failure modes:
- **Premature timeout**: Clock jumped forward, elapsed exceeds max_wait immediately
- **Infinite loop**: Clock went backward, elapsed().unwrap_or_default() returns Duration::ZERO, never times out

## Fix

Replace `SystemTime::now()` with `Instant::now()` (OS monotonic clock).

`Instant::elapsed()` returns `Duration` directly (no Result), so `.unwrap_or_default()` is also removed, eliminating silent error swallowing.

## Changed files (2 files, 10 lines)

- `crates/music/addzero-music/src/lib.rs` -- `wait_for_completion_with`, `wait_for_batch_completion_with`: SystemTime to Instant, drop unwrap_or_default()
- `crates/network/addzero-email/src/temp_mail.rs` -- `wait_for_message`, `wait_for_code`: SystemTime to Instant, drop unwrap_or_default()

`SystemTime` is intentionally retained in `temp_mail.rs:788` where it is used to generate a Unix timestamp (not a duration measurement).

## Verification

- `cargo check --workspace` passed
- `cargo test --workspace` all tests passed
- No breaking API changes (all modifications are internal)

Automated fix by Codex.