### PR TITLE
fix(storage): replace mutex expect with graceful recovery (#66)

### DIFF
--- a/crates/storage/addzero-minio/src/lib.rs
+++ b/crates/storage/addzero-minio/src/lib.rs
@@ -475,11 +475,25 @@ pub fn create_client_with_credentials(
     create_client(MinioConfig::new(endpoint, access_key, secret_key))
 }
 
+/// Recover from a poisoned RwLock read guard instead of panicking.
+fn recover_rwlock_read<T>(rwlock: &std::sync::RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
+    rwlock.read().unwrap_or_else(|poisoned| {
+        eprintln!("WARN: minio client cache was poisoned, recovering");
+        poisoned.into_inner()
+    })
+}
+
+/// Recover from a poisoned RwLock write guard instead of panicking.
+fn recover_rwlock_write<T>(rwlock: &std::sync::RwLock<T>) -> std::sync::RwLockWriteGuard<'_, T> {
+    rwlock.write().unwrap_or_else(|poisoned| {
+        eprintln!("WARN: minio client cache was poisoned, recovering");
+        poisoned.into_inner()
+    })
+}
+
 pub fn get_or_create_client(key: &str, config: MinioConfig) -> MinioResult<MinioClient> {
     let lock = CLIENTS.get_or_init(|| RwLock::new(BTreeMap::new()));
-    if let Some(existing) = lock
-        .read()
-        .expect("minio client cache should not be poisoned")
+    if let Some(existing) = recover_rwlock_read(lock)
         .get(key)
         .cloned()
     {
@@ -487,8 +501,7 @@ pub fn get_or_create_client(key: &str, config: MinioConfig) -> MinioResult<Minio
     }
 
     let client = create_client(config)?;
-    lock.write()
-        .expect("minio client cache should not be poisoned")
+    recover_rwlock_write(lock)
         .insert(key.to_owned(), client.clone());
     Ok(client)
 }

--- a/crates/storage/addzero-rustfs/src/client.rs
+++ b/crates/storage/addzero-rustfs/src/client.rs
@@ -17,6 +17,14 @@ use thiserror::Error;
 
 type HmacSha256 = Hmac<Sha256>;
 
+/// Recover from a poisoned mutex instead of panicking.
+fn recover_lock<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|poisoned| {
+        eprintln!("WARN: in-memory storage mutex was poisoned, recovering");
+        poisoned.into_inner()
+    })
+}
+
 const AWS_SERVICE_NAME: &str = "s3";
 const UNSIGNED_PAYLOAD: &str = "UNSIGNED-PAYLOAD";
 
@@ -1448,18 +1456,16 @@ impl InMemoryS3StorageClient {
 
 impl S3StorageClient for InMemoryS3StorageClient {
     fn bucket_exists(&self, bucket_name: &str) -> StorageResult<bool> {
-        Ok(self
+        Ok(recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+            )
             .buckets
             .contains_key(bucket_name))
     }
 
     fn create_bucket(&self, bucket_name: &str) -> StorageResult<()> {
-        self.state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+        recover_lock(&self.state
+            )
             .buckets
             .entry(bucket_name.to_owned())
             .or_default();
@@ -1467,10 +1473,9 @@ impl S3StorageClient for InMemoryS3StorageClient {
     }
 
     fn list_buckets(&self) -> StorageResult<Vec<String>> {
-        Ok(self
+        Ok(recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+            )
             .buckets
             .keys()
             .cloned()
@@ -1478,9 +1483,8 @@ impl S3StorageClient for InMemoryS3StorageClient {
     }
 
     fn delete_bucket(&self, bucket_name: &str) -> StorageResult<()> {
-        self.state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+        recover_lock(&self.state
+            )
             .buckets
             .remove(bucket_name)
             .ok_or_else(|| StorageError::BucketNotFound {
@@ -1490,10 +1494,9 @@ impl S3StorageClient for InMemoryS3StorageClient {
     }
 
     fn object_exists(&self, bucket_name: &str, key: &str) -> StorageResult<bool> {
-        Ok(self
+        Ok(recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+            )
             .buckets
             .get(bucket_name)
             .and_then(|bucket| bucket.get(key))
@@ -1505,10 +1508,9 @@ impl S3StorageClient for InMemoryS3StorageClient {
         bucket_name: &str,
         key: &str,
     ) -> StorageResult<Option<ObjectMetadata>> {
-        Ok(self
+        Ok(recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+            )
             .buckets
             .get(bucket_name)
             .and_then(|bucket| bucket.get(key))
@@ -1523,10 +1525,9 @@ impl S3StorageClient for InMemoryS3StorageClient {
         content_type: Option<&str>,
         metadata: &BTreeMap<String, String>,
     ) -> StorageResult<()> {
-        let mut state = self
+        let mut state = recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned");
+            );
         let etag = Self::next_id(&mut state, "etag");
         state
             .buckets
@@ -1558,9 +1559,8 @@ impl S3StorageClient for InMemoryS3StorageClient {
     }
 
     fn get_object(&self, bucket_name: &str, key: &str) -> StorageResult<Vec<u8>> {
-        self.state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+        recover_lock(&self.state
+            )
             .buckets
             .get(bucket_name)
             .and_then(|bucket| bucket.get(key))
@@ -1581,9 +1581,8 @@ impl S3StorageClient for InMemoryS3StorageClient {
     }
 
     fn delete_object(&self, bucket_name: &str, key: &str) -> StorageResult<()> {
-        self.state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+        recover_lock(&self.state
+            )
             .buckets
             .get_mut(bucket_name)
             .and_then(|bucket| bucket.remove(key))
@@ -1629,10 +1628,9 @@ impl S3StorageClient for InMemoryS3StorageClient {
         max_keys: usize,
     ) -> StorageResult<Vec<ObjectMetadata>> {
         let prefix = prefix.unwrap_or_default();
-        let bucket = self
+        let bucket = recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+            )
             .buckets
             .get(bucket_name)
             .cloned()
@@ -1656,10 +1654,9 @@ impl S3StorageClient for InMemoryS3StorageClient {
         content_type: Option<&str>,
         metadata: &BTreeMap<String, String>,
     ) -> StorageResult<String> {
-        let mut state = self
+        let mut state = recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned");
+            );
         let upload_id = Self::next_id(&mut state, "upload");
         state.uploads.insert(
             upload_id.clone(),
@@ -1683,10 +1680,9 @@ impl S3StorageClient for InMemoryS3StorageClient {
         data: &[u8],
         _content_type: Option<&str>,
     ) -> StorageResult<String> {
-        let mut state = self
+        let mut state = recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned");
+            );
         let upload = state
             .uploads
             .get_mut(upload_id)
@@ -1702,10 +1698,9 @@ impl S3StorageClient for InMemoryS3StorageClient {
         upload_id: &str,
         parts: &[PartInfo],
     ) -> StorageResult<()> {
-        let mut state = self
+        let mut state = recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned");
+            );
         let upload = state
             .uploads
             .remove(upload_id)
@@ -1743,19 +1738,17 @@ impl S3StorageClient for InMemoryS3StorageClient {
         _key: &str,
         upload_id: &str,
     ) -> StorageResult<()> {
-        self.state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+        recover_lock(&self.state
+            )
             .uploads
             .remove(upload_id);
         Ok(())
     }
 
     fn list_multipart_uploads(&self, bucket_name: &str) -> StorageResult<Vec<String>> {
-        Ok(self
+        Ok(recover_lock(&self
             .state
-            .lock()
-            .expect("in-memory storage mutex should not be poisoned")
+            )
             .uploads
             .iter()
             .filter(|(_, upload)| upload.bucket_name == bucket_name)

--- a/crates/storage/addzero-rustfs/src/progress.rs
+++ b/crates/storage/addzero-rustfs/src/progress.rs
@@ -3,6 +3,14 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+/// Recover from a poisoned mutex instead of panicking.
+fn recover_lock<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|poisoned| {
+        eprintln!("WARN: upload progress mutex was poisoned, recovering");
+        poisoned.into_inner()
+    })
+}
+
 pub trait UploadProgressListener: Send + Sync {
     fn on_progress(&self, progress: UploadProgressData);
 }
@@ -213,25 +221,22 @@ impl InMemoryUploadProgressStorage {
 
 impl UploadProgressStorage for InMemoryUploadProgressStorage {
     fn save_status(&self, key: &str, status: UploadStatus) -> bool {
-        self.state
-            .lock()
-            .expect("upload progress storage mutex should not be poisoned")
+        recover_lock(&self.state
+            )
             .insert(key.to_owned(), status);
         true
     }
 
     fn get_status(&self, key: &str) -> Option<UploadStatus> {
-        self.state
-            .lock()
-            .expect("upload progress storage mutex should not be poisoned")
+        recover_lock(&self.state
+            )
             .get(key)
             .cloned()
     }
 
     fn delete_status(&self, key: &str) -> bool {
-        self.state
-            .lock()
-            .expect("upload progress storage mutex should not be poisoned")
+        recover_lock(&self.state
+            )
             .remove(key)
             .is_some()
     }
@@ -243,10 +248,9 @@ impl UploadProgressStorage for InMemoryUploadProgressStorage {
         status: PartStatus,
         etag: Option<String>,
     ) -> bool {
-        let mut state = self
+        let mut state = recover_lock(&self
             .state
-            .lock()
-            .expect("upload progress storage mutex should not be poisoned");
+            );
         let Some(current) = state.get_mut(key) else {
             return false;
         };
@@ -279,10 +283,9 @@ impl UploadProgressStorage for InMemoryUploadProgressStorage {
     }
 
     fn update_uploaded_size(&self, key: &str, uploaded_size: u64) -> bool {
-        let mut state = self
+        let mut state = recover_lock(&self
             .state
-            .lock()
-            .expect("upload progress storage mutex should not be poisoned");
+            );
         let Some(current) = state.get_mut(key) else {
             return false;
         };
@@ -318,19 +321,17 @@ impl SpeedTrackingProgressListener {
     }
 
     pub fn reset(&self) {
-        *self
+        *recover_lock(&self
             .last_sample
-            .lock()
-            .expect("progress listener mutex should not be poisoned") = None;
+            ) = None;
     }
 }
 
 impl UploadProgressListener for SpeedTrackingProgressListener {
     fn on_progress(&self, progress: UploadProgressData) {
-        let mut last_sample = self
+        let mut last_sample = recover_lock(&self
             .last_sample
-            .lock()
-            .expect("progress listener mutex should not be poisoned");
+            );
         let now = Instant::now();
 
         let speed = last_sample.as_ref().and_then(|(instant, uploaded)| {


### PR DESCRIPTION
Closes #66

## Problem
 and  contain 24  calls on  /  that panic on poisoned locks, causing storage-layer cascade failures.

## Solution
Replaced all 24  calls with  /  /  helper functions that:
- Log a warning via 
- Recover the inner value from the poisoned lock
- Continue normal operation instead of panicking

### Files changed
-  — 15 sites → 
-  — 9 sites →  (7  + 2 )
-  — 2 sites → 

## Verification
-  ✅
-  ✅
- 
running 2 tests
test client::tests::parse_list_objects_response_should_capture_pagination_fields ... ok
test client::tests::parse_list_objects_response_should_capture_common_prefixes ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test presigned_url_uses_virtual_host_when_path_style_disabled ... ok
test blocking_client_supports_multipart_upload_flow ... ok
test blocking_client_supports_bucket_and_object_lifecycle ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.05s


running 6 tests
test client_config_and_rustfs_defaults_match_expected_values ... ok
test progress_helpers_compute_expected_values ... ok
test build_list_request_and_presigned_helpers_match_expected_shape ... ok
test in_memory_client_supports_bucket_and_object_lifecycle ... ok
test speed_tracking_listener_calculates_speed_and_updates_storage ... ok
test multipart_upload_and_resume_helpers_work_with_in_memory_client ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.16s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s — 9 tests passed ✅
- 
running 6 tests
test tests::config_builder_matches_minio_defaults ... ok
test tests::bucket_and_object_lifecycle_matches_jvm_api ... ok
test tests::file_upload_and_presigned_url_are_supported ... ok
test tests::cached_clients_reuse_the_same_key ... ok
test tests::upload_text_and_encrypt_url_returns_plain_and_encrypted_values ... ok
test tests::url_cipher_roundtrip_works ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.02s


running 4 tests
test config_builder_matches_minio_defaults ... ok
test bucket_and_object_lifecycle_matches_jvm_api ... ok
test file_upload_and_presigned_url_are_supported ... ok
test cached_clients_reuse_the_same_key ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s — 10 tests passed ✅

Automated fix by Codex.