### PR TITLE
feat(lowcode): #76 栅格布局引擎 — CSS Grid mapping + responsive breakpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addzero-lowcode"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "rhai",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "addzero-math"
 version = "0.1.0"
 dependencies = [
@@ -714,6 +729,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1452,6 +1481,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const-serialize"
@@ -5033,6 +5082,9 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -5450,6 +5502,12 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-pty"
@@ -6067,6 +6125,34 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rhai"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
+dependencies = [
+ "ahash",
+ "bitflags 2.11.1",
+ "num-traits",
+ "once_cell",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+ "thin-vec",
+ "web-time",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4322a2a4e8cf30771dd9f27f7f37ca9ac8fe812dddd811096a98483080dabe6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6971,6 +7057,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7539,6 +7636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7616,6 +7719,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/storage/*",
     "crates/text/*",
     "crates/ui/*",
+    "crates/apps/addzero-lowcode",
 ]
 exclude = ["apps/remote-desktop"]
 
@@ -67,6 +68,7 @@ sea-orm = { version = "1.1.20", default-features = false, features = ["macros", 
 sea-orm-migration = { version = "1.1.20", default-features = false, features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 futures-util = "0.3.31"
 quinn = { version = "0.11.9", default-features = false, features = ["runtime-tokio", "rustls"] }
+axum = { version = "0.8.6", features = ["http1", "json", "tokio", "ws"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/apps/addzero-lowcode/Cargo.toml
+++ b/crates/apps/addzero-lowcode/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "addzero-lowcode"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+axum = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+sqlx = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+rhai = "1.20"
+
+[lints]
+workspace = true

--- a/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
+++ b/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
@@ -1,50 +1,44 @@
--- Lowcode service — initial schema
--- Tables follow the all-in-pg convention.
+-- Lowcode service — initial schema (issue #75)
+-- Tables follow the all-in-pg convention with lc_ prefix.
 
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- ---------------------------------------------------------------------------
--- layouts: top-level container of component nodes
+-- lc_layout: top-level container with JSONB schema + optimistic versioning
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS lowcode_layouts (
+CREATE TABLE IF NOT EXISTS lc_layout (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name        TEXT NOT NULL,
-    nodes       JSONB NOT NULL DEFAULT '[]'::jsonb,
+    schema      JSONB NOT NULL,
+    version     INT NOT NULL DEFAULT 1,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- ---------------------------------------------------------------------------
--- component_defs: registered component type metadata
+-- lc_component: registered component type metadata
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS lowcode_component_defs (
-    type_name    TEXT PRIMARY KEY,
-    props_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
-    category     TEXT NOT NULL DEFAULT 'general',
-    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS lc_component (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    type_key      TEXT NOT NULL UNIQUE,
+    props_schema  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    category      TEXT NOT NULL DEFAULT 'basic',
+    icon          TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- ---------------------------------------------------------------------------
--- templates: reusable layout templates
+-- lc_event_binding: bindings that connect component events to handlers
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS lowcode_templates (
-    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name       TEXT NOT NULL,
-    layout     JSONB NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS lc_event_binding (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    layout_id        UUID NOT NULL REFERENCES lc_layout(id) ON DELETE CASCADE,
+    component_path   TEXT NOT NULL,
+    event_type       TEXT NOT NULL,
+    handler_type     TEXT NOT NULL,
+    handler_config   JSONB NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- ---------------------------------------------------------------------------
--- event_bindings: bindings that connect component events to handlers
--- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS lowcode_event_bindings (
-    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    layout_id    UUID NOT NULL REFERENCES lowcode_layouts(id) ON DELETE CASCADE,
-    node_id      UUID NOT NULL,
-    event_name   TEXT NOT NULL,
-    handler      JSONB NOT NULL,
-    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_event_bindings_layout
-    ON lowcode_event_bindings(layout_id);
+CREATE INDEX IF NOT EXISTS idx_event_binding_layout
+    ON lc_event_binding(layout_id);

--- a/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
+++ b/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
@@ -1,0 +1,50 @@
+-- Lowcode service — initial schema
+-- Tables follow the all-in-pg convention.
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- layouts: top-level container of component nodes
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_layouts (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL,
+    nodes       JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- component_defs: registered component type metadata
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_component_defs (
+    type_name    TEXT PRIMARY KEY,
+    props_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
+    category     TEXT NOT NULL DEFAULT 'general',
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- templates: reusable layout templates
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_templates (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name       TEXT NOT NULL,
+    layout     JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- event_bindings: bindings that connect component events to handlers
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_event_bindings (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    layout_id    UUID NOT NULL REFERENCES lowcode_layouts(id) ON DELETE CASCADE,
+    node_id      UUID NOT NULL,
+    event_name   TEXT NOT NULL,
+    handler      JSONB NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_bindings_layout
+    ON lowcode_event_bindings(layout_id);

--- a/crates/apps/addzero-lowcode/src/editor.rs
+++ b/crates/apps/addzero-lowcode/src/editor.rs
@@ -1,0 +1,14 @@
+/// Canvas editor operations (skeleton — to be implemented in #78).
+pub struct CanvasEditor;
+
+impl CanvasEditor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CanvasEditor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/events.rs
+++ b/crates/apps/addzero-lowcode/src/events.rs
@@ -1,0 +1,15 @@
+/// Event system and handler registry (skeleton — to be implemented in #79).
+#[derive(Clone)]
+pub struct HandlerRegistry;
+
+impl HandlerRegistry {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HandlerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/grid.rs
+++ b/crates/apps/addzero-lowcode/src/grid.rs
@@ -1,0 +1,14 @@
+/// Grid-based layout engine (skeleton — to be implemented in #76).
+pub struct GridEngine;
+
+impl GridEngine {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for GridEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/grid.rs
+++ b/crates/apps/addzero-lowcode/src/grid.rs
@@ -1,14 +1,382 @@
-/// Grid-based layout engine (skeleton — to be implemented in #76).
+use crate::schema::{Breakpoint, ComponentNode, GridArea, GridDefinition, LayoutSchema};
+
+/// Default grid column count used when a schema provides an invalid zero value.
+pub const DEFAULT_COLUMNS: u16 = 12;
+
+/// Grid-based layout engine that maps layout schema nodes onto CSS Grid rules.
+#[derive(Debug, Clone, Copy)]
 pub struct GridEngine;
 
 impl GridEngine {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
+    }
+
+    pub fn compile_css(layout: &LayoutSchema) -> String {
+        Self::new().render_css(layout)
+    }
+
+    pub fn render_css(&self, layout: &LayoutSchema) -> String {
+        let mut blocks = vec![render_canvas_rule(&layout.grid)];
+        let mut nested_container_selectors = Vec::new();
+
+        collect_node_blocks(
+            &layout.children,
+            &layout.grid,
+            &mut blocks,
+            &mut nested_container_selectors,
+        );
+
+        for breakpoint in &layout.grid.breakpoints {
+            blocks.push(render_breakpoint_block(
+                breakpoint,
+                &layout.grid,
+                &nested_container_selectors,
+            ));
+        }
+
+        blocks.join("\n\n")
     }
 }
 
 impl Default for GridEngine {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub fn compile_css(layout: &LayoutSchema) -> String {
+    GridEngine::compile_css(layout)
+}
+
+impl GridArea {
+    pub fn to_css(&self) -> String {
+        format!(
+            "grid-column: {} / {}; grid-row: {} / {};",
+            self.col_start, self.col_end, self.row_start, self.row_end
+        )
+    }
+}
+
+fn collect_node_blocks(
+    nodes: &[ComponentNode],
+    grid: &GridDefinition,
+    blocks: &mut Vec<String>,
+    nested_container_selectors: &mut Vec<String>,
+) {
+    for node in nodes {
+        if !node.children.is_empty() {
+            nested_container_selectors.push(node_selector(&node.id));
+        }
+
+        blocks.push(render_node_rule(node, grid));
+        collect_node_blocks(&node.children, grid, blocks, nested_container_selectors);
+    }
+}
+
+fn render_canvas_rule(grid: &GridDefinition) -> String {
+    render_rule(".lc-canvas", grid_properties(grid, true))
+}
+
+fn render_node_rule(node: &ComponentNode, grid: &GridDefinition) -> String {
+    let mut declarations = vec![node.grid_area.to_css()];
+
+    if !node.children.is_empty() {
+        declarations.extend(grid_properties(grid, true));
+    }
+
+    render_rule(&node_selector(&node.id), declarations)
+}
+
+fn render_breakpoint_block(
+    breakpoint: &Breakpoint,
+    base_grid: &GridDefinition,
+    nested_container_selectors: &[String],
+) -> String {
+    let mut rules = Vec::with_capacity(nested_container_selectors.len() + 1);
+    let declarations = breakpoint_properties(breakpoint, base_grid);
+
+    rules.push(indent_block(&render_rule(
+        ".lc-canvas",
+        declarations.clone(),
+    )));
+
+    for selector in nested_container_selectors {
+        rules.push(indent_block(&render_rule(selector, declarations.clone())));
+    }
+
+    format!(
+        "@media (max-width: {}) {{\n{}\n}}",
+        breakpoint.max_width,
+        rules.join("\n\n")
+    )
+}
+
+fn grid_properties(grid: &GridDefinition, include_display: bool) -> Vec<String> {
+    let mut declarations = Vec::with_capacity(4);
+
+    if include_display {
+        declarations.push("display: grid;".to_string());
+    }
+
+    declarations.push(format!(
+        "grid-template-columns: repeat({}, minmax(0, 1fr));",
+        resolved_columns(grid.columns)
+    ));
+    declarations.push(format!(
+        "grid-template-rows: repeat({}, {});",
+        resolved_rows(grid.rows),
+        row_track_size(grid.row_height.as_deref())
+    ));
+
+    if let Some(gap) = grid.gap.as_deref() {
+        declarations.push(format!("gap: {gap};"));
+    }
+
+    declarations
+}
+
+fn breakpoint_properties(breakpoint: &Breakpoint, base_grid: &GridDefinition) -> Vec<String> {
+    let mut declarations = Vec::with_capacity(3);
+
+    declarations.push(format!(
+        "grid-template-columns: repeat({}, minmax(0, 1fr));",
+        resolved_breakpoint_columns(breakpoint.columns)
+    ));
+
+    if let Some(row_height) = breakpoint.row_height.as_deref() {
+        declarations.push(format!(
+            "grid-template-rows: repeat({}, {});",
+            resolved_rows(base_grid.rows),
+            row_height
+        ));
+    }
+
+    if let Some(gap) = breakpoint.gap.as_deref() {
+        declarations.push(format!("gap: {gap};"));
+    }
+
+    declarations
+}
+
+fn render_rule(selector: &str, declarations: Vec<String>) -> String {
+    let mut css = String::new();
+    css.push_str(selector);
+    css.push_str(" {\n");
+
+    for declaration in declarations {
+        css.push_str("  ");
+        css.push_str(&declaration);
+        if !declaration.ends_with(';') {
+            css.push(';');
+        }
+        css.push('\n');
+    }
+
+    css.push('}');
+    css
+}
+
+fn indent_block(block: &str) -> String {
+    let mut indented = String::new();
+
+    for line in block.lines() {
+        indented.push_str("  ");
+        indented.push_str(line);
+        indented.push('\n');
+    }
+
+    indented.pop();
+    indented
+}
+
+fn node_selector(node_id: &str) -> String {
+    format!(".lc-node-{node_id}")
+}
+
+fn row_track_size(row_height: Option<&str>) -> &str {
+    row_height.unwrap_or("minmax(0, auto)")
+}
+
+fn resolved_columns(columns: u32) -> u32 {
+    if columns == 0 {
+        u32::from(DEFAULT_COLUMNS)
+    } else {
+        columns
+    }
+}
+
+fn resolved_breakpoint_columns(columns: u16) -> u16 {
+    if columns == 0 {
+        DEFAULT_COLUMNS
+    } else {
+        columns
+    }
+}
+
+fn resolved_rows(rows: u32) -> u32 {
+    rows.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{Breakpoint, ComponentNode};
+
+    #[test]
+    fn grid_area_to_css_should_render_basic_range() {
+        let area = GridArea {
+            col_start: 1,
+            col_end: 3,
+            row_start: 2,
+            row_end: 4,
+        };
+
+        assert_eq!(area.to_css(), "grid-column: 1 / 3; grid-row: 2 / 4;");
+    }
+
+    #[test]
+    fn grid_area_to_css_should_render_various_ranges() {
+        let area = GridArea {
+            col_start: 3,
+            col_end: 7,
+            row_start: 1,
+            row_end: 9,
+        };
+
+        assert_eq!(area.to_css(), "grid-column: 3 / 7; grid-row: 1 / 9;");
+    }
+
+    #[test]
+    fn compile_css_should_render_simple_two_node_layout() {
+        let layout = layout_with_children(
+            base_grid_definition(),
+            vec![
+                node("header", 1, 13, 1, 2, vec![]),
+                node("content", 1, 13, 2, 7, vec![]),
+            ],
+        );
+
+        let css = compile_css(&layout);
+
+        assert!(css.contains(".lc-canvas {"));
+        assert!(css.contains("display: grid;"));
+        assert!(css.contains("grid-template-columns: repeat(12, minmax(0, 1fr));"));
+        assert!(css.contains("grid-template-rows: repeat(6, 80px);"));
+        assert!(css.contains("gap: 16px;"));
+        assert!(css.contains(".lc-node-header {"));
+        assert!(css.contains("grid-column: 1 / 13; grid-row: 1 / 2;"));
+        assert!(css.contains(".lc-node-content {"));
+        assert!(css.contains("grid-column: 1 / 13; grid-row: 2 / 7;"));
+    }
+
+    #[test]
+    fn compile_css_should_render_breakpoint_media_queries() {
+        let mut grid = base_grid_definition();
+        grid.breakpoints = vec![
+            Breakpoint {
+                name: "tablet".into(),
+                max_width: "1024px".into(),
+                columns: 8,
+                row_height: Some("64px".into()),
+                gap: Some("12px".into()),
+            },
+            Breakpoint {
+                name: "mobile".into(),
+                max_width: "640px".into(),
+                columns: 4,
+                row_height: None,
+                gap: None,
+            },
+        ];
+
+        let layout = layout_with_children(grid, vec![node("hero", 1, 13, 1, 4, vec![])]);
+        let css = GridEngine::compile_css(&layout);
+
+        assert!(css.contains("@media (max-width: 1024px) {"));
+        assert!(css.contains("grid-template-columns: repeat(8, minmax(0, 1fr));"));
+        assert!(css.contains("grid-template-rows: repeat(6, 64px);"));
+        assert!(css.contains("gap: 12px;"));
+        assert!(css.contains("@media (max-width: 640px) {"));
+        assert!(css.contains("grid-template-columns: repeat(4, minmax(0, 1fr));"));
+    }
+
+    #[test]
+    fn compile_css_should_render_nested_container_grids() {
+        let layout = layout_with_children(
+            base_grid_definition(),
+            vec![node(
+                "container",
+                1,
+                13,
+                1,
+                7,
+                vec![
+                    node("child-a", 1, 7, 1, 3, vec![]),
+                    node("child-b", 7, 13, 1, 3, vec![]),
+                ],
+            )],
+        );
+
+        let css = compile_css(&layout);
+
+        assert!(css.contains(".lc-node-container {"));
+        assert!(css.contains(".lc-node-child-a {"));
+        assert!(css.contains(".lc-node-child-b {"));
+        assert!(css.contains(
+            ".lc-node-container {\n  grid-column: 1 / 13; grid-row: 1 / 7;\n  display: grid;"
+        ));
+        assert!(css.contains(".lc-node-child-a {\n  grid-column: 1 / 7; grid-row: 1 / 3;"));
+    }
+
+    #[test]
+    fn compile_css_should_handle_empty_children() {
+        let layout = layout_with_children(base_grid_definition(), vec![]);
+
+        let css = compile_css(&layout);
+
+        assert!(css.contains(".lc-canvas {"));
+        assert!(!css.contains(".lc-node-"));
+    }
+
+    #[test]
+    fn default_columns_should_match_expected_grid_width() {
+        assert_eq!(DEFAULT_COLUMNS, 12);
+    }
+
+    fn base_grid_definition() -> GridDefinition {
+        GridDefinition {
+            columns: 12,
+            rows: 6,
+            gap: Some("16px".into()),
+            row_height: Some("80px".into()),
+            breakpoints: vec![],
+        }
+    }
+
+    fn layout_with_children(grid: GridDefinition, children: Vec<ComponentNode>) -> LayoutSchema {
+        LayoutSchema { grid, children }
+    }
+
+    fn node(
+        id: &str,
+        col_start: u32,
+        col_end: u32,
+        row_start: u32,
+        row_end: u32,
+        children: Vec<ComponentNode>,
+    ) -> ComponentNode {
+        ComponentNode {
+            id: id.into(),
+            type_key: "container".into(),
+            props: serde_json::json!({}),
+            grid_area: GridArea {
+                col_start,
+                col_end,
+                row_start,
+                row_end,
+            },
+            children,
+        }
     }
 }

--- a/crates/apps/addzero-lowcode/src/lib.rs
+++ b/crates/apps/addzero-lowcode/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod schema;
+pub mod grid;
+pub mod registry;
+pub mod editor;
+pub mod events;
+pub mod scripting;
+pub mod render;
+pub mod template;
+pub mod repo;
+pub mod router;
+pub mod state;
+
+pub use router::lowcode_router;
+pub use state::LowcodeState;

--- a/crates/apps/addzero-lowcode/src/lib.rs
+++ b/crates/apps/addzero-lowcode/src/lib.rs
@@ -1,18 +1,19 @@
-pub mod schema;
-pub mod grid;
-pub mod registry;
 pub mod editor;
 pub mod events;
-pub mod scripting;
+pub mod grid;
+pub mod registry;
 pub mod render;
-pub mod template;
 pub mod repo;
 pub mod router;
+pub mod schema;
+pub mod scripting;
 pub mod state;
+pub mod template;
 
 // Re-export core schema types
+pub use grid::{DEFAULT_COLUMNS, GridEngine, compile_css};
 pub use schema::{
-    ComponentDefRecord, ComponentNode, EventBindingRecord, GridArea, GridDefinition,
+    Breakpoint, ComponentDefRecord, ComponentNode, EventBindingRecord, GridArea, GridDefinition,
     HandlerType, LayoutSchema,
 };
 

--- a/crates/apps/addzero-lowcode/src/lib.rs
+++ b/crates/apps/addzero-lowcode/src/lib.rs
@@ -10,5 +10,14 @@ pub mod repo;
 pub mod router;
 pub mod state;
 
+// Re-export core schema types
+pub use schema::{
+    ComponentDefRecord, ComponentNode, EventBindingRecord, GridArea, GridDefinition,
+    HandlerType, LayoutSchema,
+};
+
+// Re-export repository trait and record
+pub use repo::{LayoutRecord, LayoutRepository, PgLayoutRepo, RepoError};
+
 pub use router::lowcode_router;
 pub use state::LowcodeState;

--- a/crates/apps/addzero-lowcode/src/registry.rs
+++ b/crates/apps/addzero-lowcode/src/registry.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+use crate::schema::ComponentDef;
+
+/// In-memory component type registry (skeleton — to be fleshed out in #77).
+#[derive(Clone)]
+pub struct ComponentRegistry {
+    components: HashMap<String, ComponentDef>,
+}
+
+impl ComponentRegistry {
+    pub fn new() -> Self {
+        Self {
+            components: HashMap::new(),
+        }
+    }
+
+    /// Register a new component definition.
+    pub fn register(&mut self, def: ComponentDef) {
+        self.components.insert(def.type_name.clone(), def);
+    }
+
+    /// Look up a component by type name.
+    pub fn get(&self, type_name: &str) -> Option<&ComponentDef> {
+        self.components.get(type_name)
+    }
+
+    /// List all registered component definitions.
+    pub fn list(&self) -> Vec<&ComponentDef> {
+        self.components.values().collect()
+    }
+}
+
+impl Default for ComponentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/registry.rs
+++ b/crates/apps/addzero-lowcode/src/registry.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use crate::schema::ComponentDef;
+use crate::schema::ComponentDefRecord;
 
 /// In-memory component type registry (skeleton — to be fleshed out in #77).
 #[derive(Clone)]
 pub struct ComponentRegistry {
-    components: HashMap<String, ComponentDef>,
+    components: HashMap<String, ComponentDefRecord>,
 }
 
 impl ComponentRegistry {
@@ -16,17 +16,17 @@ impl ComponentRegistry {
     }
 
     /// Register a new component definition.
-    pub fn register(&mut self, def: ComponentDef) {
-        self.components.insert(def.type_name.clone(), def);
+    pub fn register(&mut self, def: ComponentDefRecord) {
+        self.components.insert(def.type_key.clone(), def);
     }
 
-    /// Look up a component by type name.
-    pub fn get(&self, type_name: &str) -> Option<&ComponentDef> {
-        self.components.get(type_name)
+    /// Look up a component by type key.
+    pub fn get(&self, type_key: &str) -> Option<&ComponentDefRecord> {
+        self.components.get(type_key)
     }
 
     /// List all registered component definitions.
-    pub fn list(&self) -> Vec<&ComponentDef> {
+    pub fn list(&self) -> Vec<&ComponentDefRecord> {
         self.components.values().collect()
     }
 }

--- a/crates/apps/addzero-lowcode/src/render.rs
+++ b/crates/apps/addzero-lowcode/src/render.rs
@@ -1,6 +1,6 @@
 /// Render pipeline — converts a layout tree into output (skeleton — to be implemented in #81).
 
-use crate::schema::Layout;
+use crate::schema::LayoutSchema;
 
 /// Errors that can occur during rendering.
 #[derive(Debug, thiserror::Error)]
@@ -22,7 +22,6 @@ pub struct RenderOutput {
 /// Renders a layout into a preview-ready output.
 ///
 /// The actual rendering logic will be fleshed out in #81.
-pub fn render(layout: &Layout) -> Result<RenderOutput, RenderError> {
-    let _ = layout;
+pub fn render(_layout: &LayoutSchema) -> Result<RenderOutput, RenderError> {
     todo!("render pipeline — will be implemented in #81")
 }

--- a/crates/apps/addzero-lowcode/src/render.rs
+++ b/crates/apps/addzero-lowcode/src/render.rs
@@ -1,0 +1,28 @@
+/// Render pipeline — converts a layout tree into output (skeleton — to be implemented in #81).
+
+use crate::schema::Layout;
+
+/// Errors that can occur during rendering.
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    #[error("layout not found: {0}")]
+    LayoutNotFound(uuid::Uuid),
+    #[error("unsupported component type: {0}")]
+    UnsupportedComponent(String),
+    #[error("render pipeline error: {0}")]
+    Pipeline(String),
+}
+
+/// Placeholder render result.
+#[derive(Debug, Clone)]
+pub struct RenderOutput {
+    pub html: String,
+}
+
+/// Renders a layout into a preview-ready output.
+///
+/// The actual rendering logic will be fleshed out in #81.
+pub fn render(layout: &Layout) -> Result<RenderOutput, RenderError> {
+    let _ = layout;
+    todo!("render pipeline — will be implemented in #81")
+}

--- a/crates/apps/addzero-lowcode/src/repo.rs
+++ b/crates/apps/addzero-lowcode/src/repo.rs
@@ -1,8 +1,14 @@
-/// PG repository for lowcode layouts (skeleton — to be fleshed out in subsequent issues).
+//! CRUD repository trait + PG implementation for lowcode layouts.
 
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::schema::Layout;
+use crate::schema::LayoutSchema;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
 
 /// Errors from layout repository operations.
 #[derive(Debug, thiserror::Error)]
@@ -13,39 +19,91 @@ pub enum RepoError {
     Database(#[from] sqlx::Error),
 }
 
-/// Layout repository backed by PostgreSQL (skeleton).
+// ---------------------------------------------------------------------------
+// Persisted record — the row-level shape stored in PG `lc_layout`
+// ---------------------------------------------------------------------------
+
+/// A layout row as stored in / read from PostgreSQL.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutRecord {
+    pub id: Uuid,
+    pub name: String,
+    pub schema: LayoutSchema,
+    pub version: i32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Repository trait
+// ---------------------------------------------------------------------------
+
+/// CRUD operations for lowcode layouts.
+#[async_trait]
+pub trait LayoutRepository: Send + Sync {
+    /// Insert a new layout and return the created record.
+    async fn create(&self, name: &str, schema: &LayoutSchema) -> Result<LayoutRecord, RepoError>;
+
+    /// Get a layout by id.
+    async fn get(&self, id: Uuid) -> Result<LayoutRecord, RepoError>;
+
+    /// List all layouts.
+    async fn list(&self) -> Result<Vec<LayoutRecord>, RepoError>;
+
+    /// Update layout name and/or schema. Returns the updated record.
+    async fn update(
+        &self,
+        id: Uuid,
+        name: &str,
+        schema: &LayoutSchema,
+    ) -> Result<LayoutRecord, RepoError>;
+
+    /// Delete a layout by id.
+    async fn delete(&self, id: Uuid) -> Result<(), RepoError>;
+}
+
+// ---------------------------------------------------------------------------
+// PG implementation (queries will be wired up once PG is connected)
+// ---------------------------------------------------------------------------
+
+/// PostgreSQL-backed layout repository.
 ///
-/// The actual query implementations will be added alongside issues #75–#81.
-pub struct LayoutRepo;
+/// Query bodies are `todo!()` stubs — they will be filled in when the PG
+/// connection is wired up. The trait signatures are final.
+pub struct PgLayoutRepo {
+    _pool: sqlx::PgPool,
+}
 
-impl LayoutRepo {
-    pub fn new() -> Self {
-        Self
-    }
-
-    pub async fn create(&self, _layout: &Layout) -> Result<Layout, RepoError> {
-        todo!("layout create — will be implemented in #75")
-    }
-
-    pub async fn get(&self, _id: Uuid) -> Result<Layout, RepoError> {
-        todo!("layout get — will be implemented in #75")
-    }
-
-    pub async fn list(&self) -> Result<Vec<Layout>, RepoError> {
-        todo!("layout list — will be implemented in #75")
-    }
-
-    pub async fn update(&self, _layout: &Layout) -> Result<Layout, RepoError> {
-        todo!("layout update — will be implemented in #75")
-    }
-
-    pub async fn delete(&self, _id: Uuid) -> Result<(), RepoError> {
-        todo!("layout delete — will be implemented in #75")
+impl PgLayoutRepo {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { _pool: pool }
     }
 }
 
-impl Default for LayoutRepo {
-    fn default() -> Self {
-        Self::new()
+#[async_trait]
+impl LayoutRepository for PgLayoutRepo {
+    async fn create(&self, _name: &str, _schema: &LayoutSchema) -> Result<LayoutRecord, RepoError> {
+        todo!("PG create layout — will be wired to real queries")
+    }
+
+    async fn get(&self, _id: Uuid) -> Result<LayoutRecord, RepoError> {
+        todo!("PG get layout — will be wired to real queries")
+    }
+
+    async fn list(&self) -> Result<Vec<LayoutRecord>, RepoError> {
+        todo!("PG list layouts — will be wired to real queries")
+    }
+
+    async fn update(
+        &self,
+        _id: Uuid,
+        _name: &str,
+        _schema: &LayoutSchema,
+    ) -> Result<LayoutRecord, RepoError> {
+        todo!("PG update layout — will be wired to real queries")
+    }
+
+    async fn delete(&self, _id: Uuid) -> Result<(), RepoError> {
+        todo!("PG delete layout — will be wired to real queries")
     }
 }

--- a/crates/apps/addzero-lowcode/src/repo.rs
+++ b/crates/apps/addzero-lowcode/src/repo.rs
@@ -1,0 +1,51 @@
+/// PG repository for lowcode layouts (skeleton — to be fleshed out in subsequent issues).
+
+use uuid::Uuid;
+
+use crate::schema::Layout;
+
+/// Errors from layout repository operations.
+#[derive(Debug, thiserror::Error)]
+pub enum RepoError {
+    #[error("layout not found: {0}")]
+    NotFound(Uuid),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+/// Layout repository backed by PostgreSQL (skeleton).
+///
+/// The actual query implementations will be added alongside issues #75–#81.
+pub struct LayoutRepo;
+
+impl LayoutRepo {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn create(&self, _layout: &Layout) -> Result<Layout, RepoError> {
+        todo!("layout create — will be implemented in #75")
+    }
+
+    pub async fn get(&self, _id: Uuid) -> Result<Layout, RepoError> {
+        todo!("layout get — will be implemented in #75")
+    }
+
+    pub async fn list(&self) -> Result<Vec<Layout>, RepoError> {
+        todo!("layout list — will be implemented in #75")
+    }
+
+    pub async fn update(&self, _layout: &Layout) -> Result<Layout, RepoError> {
+        todo!("layout update — will be implemented in #75")
+    }
+
+    pub async fn delete(&self, _id: Uuid) -> Result<(), RepoError> {
+        todo!("layout delete — will be implemented in #75")
+    }
+}
+
+impl Default for LayoutRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/router.rs
+++ b/crates/apps/addzero-lowcode/src/router.rs
@@ -1,0 +1,161 @@
+/// Axum router for the lowcode service.
+
+use axum::{
+    Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, patch, post},
+};
+use uuid::Uuid;
+
+use crate::state::LowcodeState;
+
+// ---------------------------------------------------------------------------
+// Layout CRUD handlers (skeleton — handlers are todo!())
+// ---------------------------------------------------------------------------
+
+async fn create_layout(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "create_layout")
+}
+
+async fn list_layouts(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_layouts")
+}
+
+async fn get_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "get_layout")
+}
+
+async fn update_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_layout")
+}
+
+async fn delete_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_layout")
+}
+
+// ---------------------------------------------------------------------------
+// Canvas / node operations (skeleton — #78)
+// ---------------------------------------------------------------------------
+
+async fn place_component(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "place_component")
+}
+
+async fn update_props(
+    _state: State<LowcodeState>,
+    _path: Path<(Uuid, String)>,
+) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_props")
+}
+
+async fn delete_component(
+    _state: State<LowcodeState>,
+    _path: Path<(Uuid, String)>,
+) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_component")
+}
+
+// ---------------------------------------------------------------------------
+// Preview & render (skeleton — #81)
+// ---------------------------------------------------------------------------
+
+async fn preview_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "preview_layout")
+}
+
+async fn render_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "render_layout")
+}
+
+// ---------------------------------------------------------------------------
+// Event handling (skeleton — #79)
+// ---------------------------------------------------------------------------
+
+async fn handle_event(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "handle_event")
+}
+
+// ---------------------------------------------------------------------------
+// Scripting (skeleton — #80)
+// ---------------------------------------------------------------------------
+
+async fn validate_script(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "validate_script")
+}
+
+// ---------------------------------------------------------------------------
+// Template CRUD (skeleton — #81)
+// ---------------------------------------------------------------------------
+
+async fn create_template(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "create_template")
+}
+
+async fn list_templates(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_templates")
+}
+
+async fn get_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "get_template")
+}
+
+async fn update_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_template")
+}
+
+async fn delete_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_template")
+}
+
+// ---------------------------------------------------------------------------
+// Component registry (skeleton — #77)
+// ---------------------------------------------------------------------------
+
+async fn list_components(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_components")
+}
+
+async fn register_component(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "register_component")
+}
+
+// ---------------------------------------------------------------------------
+// Router assembly
+// ---------------------------------------------------------------------------
+
+/// Builds the full lowcode API router.
+pub fn lowcode_router(state: LowcodeState) -> Router {
+    Router::new()
+        .route("/api/lowcode/layout", post(create_layout).get(list_layouts))
+        .route(
+            "/api/lowcode/layout/{id}",
+            get(get_layout).put(update_layout).delete(delete_layout),
+        )
+        .route(
+            "/api/lowcode/layout/{id}/node",
+            post(place_component),
+        )
+        .route(
+            "/api/lowcode/layout/{id}/node/{*path}",
+            patch(update_props).delete(delete_component),
+        )
+        .route("/api/lowcode/layout/{id}/preview", get(preview_layout))
+        .route("/api/lowcode/layout/{id}/render", get(render_layout))
+        .route("/api/lowcode/event", post(handle_event))
+        .route("/api/lowcode/script/validate", post(validate_script))
+        .route(
+            "/api/lowcode/template",
+            post(create_template).get(list_templates),
+        )
+        .route(
+            "/api/lowcode/template/{id}",
+            get(get_template).put(update_template).delete(delete_template),
+        )
+        .route(
+            "/api/lowcode/component",
+            get(list_components).post(register_component),
+        )
+        .with_state(state)
+}

--- a/crates/apps/addzero-lowcode/src/schema.rs
+++ b/crates/apps/addzero-lowcode/src/schema.rs
@@ -1,83 +1,287 @@
+//! Core Schema definitions for the lowcode platform.
+//!
+//! Three-layer data model: Layout, Component, EventBinding.
+//! All types derive serde for JSON round-trip and PG JSONB storage.
+
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// A lowcode layout — the top-level container of component nodes.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Layout {
-    pub id: Uuid,
-    pub name: String,
-    pub nodes: Vec<Node>,
-    pub created_at: String,
-    pub updated_at: String,
+// ---------------------------------------------------------------------------
+// Layout schema — the top-level design document
+// ---------------------------------------------------------------------------
+
+/// A lowcode layout: grid definition + component tree.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutSchema {
+    pub grid: GridDefinition,
+    pub children: Vec<ComponentNode>,
 }
+
+/// CSS Grid container parameters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GridDefinition {
+    pub columns: u32,
+    pub rows: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gap: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Component tree — recursive nodes placed on the grid
+// ---------------------------------------------------------------------------
 
 /// A single component node in the layout tree.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Node {
-    pub id: Uuid,
-    pub component_type: String,
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentNode {
+    pub id: String,
+    pub type_key: String,
     pub props: serde_json::Value,
-    pub children: Vec<Node>,
-    pub grid_pos: Option<GridPos>,
+    pub grid_area: GridArea,
+    #[serde(default)]
+    pub children: Vec<ComponentNode>,
 }
 
-/// Position within a CSS Grid layout.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GridPos {
-    pub col: u32,
-    pub row: u32,
-    pub col_span: u32,
-    pub row_span: u32,
+/// Position within a CSS Grid layout (1-indexed, inclusive).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GridArea {
+    pub col_start: u32,
+    pub col_end: u32,
+    pub row_start: u32,
+    pub row_end: u32,
 }
 
-/// Binds a component event to an action handler.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EventBinding {
-    pub event_name: String,
-    pub handler: EventHandler,
+// ---------------------------------------------------------------------------
+// Event bindings — component event → handler coupling
+// ---------------------------------------------------------------------------
+
+/// The action to perform when a component event fires.
+///
+/// Uses adjacently-tagged serde encoding: `{"type":"…","config":{…}}`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "config")]
+pub enum HandlerType {
+    RhaiScript { script: String },
+    HttpCall {
+        url: String,
+        method: String,
+        body_template: String,
+    },
+    EmitEvent { event_name: String },
+    Noop,
 }
 
-/// The action to perform when an event fires.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", content = "value")]
-pub enum EventHandler {
-    Navigate(String),
-    Script(String),
-    Callback(String),
-}
-
-/// Metadata for a registered component type.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ComponentDef {
-    pub type_name: String,
-    pub props_schema: serde_json::Value,
-    pub category: String,
-}
-
-/// A reusable layout template.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Template {
+/// Persisted record for an event binding row (PG `lc_event_binding`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventBindingRecord {
     pub id: Uuid,
-    pub name: String,
-    pub layout: Layout,
+    pub layout_id: Uuid,
+    pub component_path: String,
+    pub event_type: String,
+    pub handler_type: HandlerType,
     pub created_at: String,
 }
+
+// ---------------------------------------------------------------------------
+// Component registry — type metadata
+// ---------------------------------------------------------------------------
+
+/// Persisted record for a registered component type (PG `lc_component`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentDefRecord {
+    pub id: Uuid,
+    pub type_key: String,
+    pub props_schema: serde_json::Value,
+    pub category: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    pub created_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Tests — serde round-trip coverage
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn smoke_grid_pos_roundtrip() {
-        let pos = GridPos {
-            col: 1,
-            row: 2,
-            col_span: 3,
-            row_span: 4,
+    fn grid_area_roundtrip() {
+        let ga = GridArea {
+            col_start: 1,
+            col_end: 3,
+            row_start: 2,
+            row_end: 4,
         };
-        let json = serde_json::to_string(&pos).unwrap();
-        let back: GridPos = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.col, 1);
-        assert_eq!(back.row_span, 4);
+        let json = serde_json::to_string(&ga).unwrap();
+        let back: GridArea = serde_json::from_str(&json).unwrap();
+        assert_eq!(ga, back);
+    }
+
+    #[test]
+    fn component_node_roundtrip() {
+        let node = ComponentNode {
+            id: "btn-1".into(),
+            type_key: "button".into(),
+            props: serde_json::json!({ "label": "Click me" }),
+            grid_area: GridArea {
+                col_start: 1,
+                col_end: 2,
+                row_start: 1,
+                row_end: 2,
+            },
+            children: vec![],
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        let back: ComponentNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, back);
+    }
+
+    #[test]
+    fn component_node_nested_roundtrip() {
+        let child = ComponentNode {
+            id: "inner".into(),
+            type_key: "text".into(),
+            props: serde_json::json!({ "content": "hello" }),
+            grid_area: GridArea {
+                col_start: 1,
+                col_end: 2,
+                row_start: 1,
+                row_end: 2,
+            },
+            children: vec![],
+        };
+        let parent = ComponentNode {
+            id: "container".into(),
+            type_key: "div".into(),
+            props: serde_json::json!({}),
+            grid_area: GridArea {
+                col_start: 1,
+                col_end: 4,
+                row_start: 1,
+                row_end: 4,
+            },
+            children: vec![child],
+        };
+        let json = serde_json::to_string(&parent).unwrap();
+        let back: ComponentNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(parent, back);
+        assert_eq!(back.children.len(), 1);
+    }
+
+    #[test]
+    fn layout_schema_roundtrip() {
+        let layout = LayoutSchema {
+            grid: GridDefinition {
+                columns: 12,
+                rows: 8,
+                gap: Some("10px".into()),
+            },
+            children: vec![ComponentNode {
+                id: "root".into(),
+                type_key: "container".into(),
+                props: serde_json::json!({}),
+                grid_area: GridArea {
+                    col_start: 1,
+                    col_end: 13,
+                    row_start: 1,
+                    row_end: 9,
+                },
+                children: vec![],
+            }],
+        };
+        let json = serde_json::to_string(&layout).unwrap();
+        let back: LayoutSchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(layout, back);
+    }
+
+    #[test]
+    fn handler_type_rhai_roundtrip() {
+        let h = HandlerType::RhaiScript {
+            script: "print(42)".into(),
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains(r#""type":"RhaiScript""#));
+        let back: HandlerType = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn handler_type_http_roundtrip() {
+        let h = HandlerType::HttpCall {
+            url: "https://api.example.com".into(),
+            method: "POST".into(),
+            body_template: r#"{"key":"{{value}}"}"#.into(),
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains(r#""type":"HttpCall""#));
+        let back: HandlerType = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn handler_type_emit_roundtrip() {
+        let h = HandlerType::EmitEvent {
+            event_name: "onSubmit".into(),
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains(r#""type":"EmitEvent""#));
+        let back: HandlerType = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn handler_type_noop_roundtrip() {
+        let h = HandlerType::Noop;
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains(r#""type":"Noop""#));
+        let back: HandlerType = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn event_binding_record_roundtrip() {
+        let rec = EventBindingRecord {
+            id: Uuid::nil(),
+            layout_id: Uuid::nil(),
+            component_path: "root/0/2".into(),
+            event_type: "onClick".into(),
+            handler_type: HandlerType::Noop,
+            created_at: "2025-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: EventBindingRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn component_def_record_roundtrip() {
+        let rec = ComponentDefRecord {
+            id: Uuid::nil(),
+            type_key: "button".into(),
+            props_schema: serde_json::json!({ "label": "string" }),
+            category: "basic".into(),
+            icon: Some("click".into()),
+            created_at: "2025-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: ComponentDefRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn component_def_record_no_icon_roundtrip() {
+        let rec = ComponentDefRecord {
+            id: Uuid::nil(),
+            type_key: "div".into(),
+            props_schema: serde_json::json!({}),
+            category: "layout".into(),
+            icon: None,
+            created_at: "2025-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(!json.contains("icon"));
+        let back: ComponentDefRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
     }
 }

--- a/crates/apps/addzero-lowcode/src/schema.rs
+++ b/crates/apps/addzero-lowcode/src/schema.rs
@@ -24,6 +24,22 @@ pub struct GridDefinition {
     pub rows: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gap: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub row_height: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub breakpoints: Vec<Breakpoint>,
+}
+
+/// Responsive CSS Grid override applied below a max viewport width.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Breakpoint {
+    pub name: String,
+    pub max_width: String,
+    pub columns: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub row_height: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gap: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -60,13 +76,17 @@ pub struct GridArea {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "config")]
 pub enum HandlerType {
-    RhaiScript { script: String },
+    RhaiScript {
+        script: String,
+    },
     HttpCall {
         url: String,
         method: String,
         body_template: String,
     },
-    EmitEvent { event_name: String },
+    EmitEvent {
+        event_name: String,
+    },
     Noop,
 }
 
@@ -176,6 +196,8 @@ mod tests {
                 columns: 12,
                 rows: 8,
                 gap: Some("10px".into()),
+                row_height: None,
+                breakpoints: vec![],
             },
             children: vec![ComponentNode {
                 id: "root".into(),

--- a/crates/apps/addzero-lowcode/src/schema.rs
+++ b/crates/apps/addzero-lowcode/src/schema.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A lowcode layout — the top-level container of component nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Layout {
+    pub id: Uuid,
+    pub name: String,
+    pub nodes: Vec<Node>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A single component node in the layout tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    pub id: Uuid,
+    pub component_type: String,
+    pub props: serde_json::Value,
+    pub children: Vec<Node>,
+    pub grid_pos: Option<GridPos>,
+}
+
+/// Position within a CSS Grid layout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GridPos {
+    pub col: u32,
+    pub row: u32,
+    pub col_span: u32,
+    pub row_span: u32,
+}
+
+/// Binds a component event to an action handler.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventBinding {
+    pub event_name: String,
+    pub handler: EventHandler,
+}
+
+/// The action to perform when an event fires.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
+pub enum EventHandler {
+    Navigate(String),
+    Script(String),
+    Callback(String),
+}
+
+/// Metadata for a registered component type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentDef {
+    pub type_name: String,
+    pub props_schema: serde_json::Value,
+    pub category: String,
+}
+
+/// A reusable layout template.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Template {
+    pub id: Uuid,
+    pub name: String,
+    pub layout: Layout,
+    pub created_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_grid_pos_roundtrip() {
+        let pos = GridPos {
+            col: 1,
+            row: 2,
+            col_span: 3,
+            row_span: 4,
+        };
+        let json = serde_json::to_string(&pos).unwrap();
+        let back: GridPos = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.col, 1);
+        assert_eq!(back.row_span, 4);
+    }
+}

--- a/crates/apps/addzero-lowcode/src/scripting.rs
+++ b/crates/apps/addzero-lowcode/src/scripting.rs
@@ -1,0 +1,15 @@
+/// Rhai scripting engine (skeleton — to be implemented in #80).
+#[derive(Clone)]
+pub struct ScriptEngine;
+
+impl ScriptEngine {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ScriptEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/state.rs
+++ b/crates/apps/addzero-lowcode/src/state.rs
@@ -1,0 +1,27 @@
+use sqlx::PgPool;
+
+use crate::events::HandlerRegistry;
+use crate::registry::ComponentRegistry;
+use crate::scripting::ScriptEngine;
+
+/// Shared application state for the lowcode service.
+///
+/// Houses the PG pool plus in-memory registries and engines.
+#[derive(Clone)]
+pub struct LowcodeState {
+    pub db: PgPool,
+    pub registry: ComponentRegistry,
+    pub script_engine: ScriptEngine,
+    pub handler_registry: HandlerRegistry,
+}
+
+impl LowcodeState {
+    pub fn new(db: PgPool) -> Self {
+        Self {
+            db,
+            registry: ComponentRegistry::new(),
+            script_engine: ScriptEngine::new(),
+            handler_registry: HandlerRegistry::new(),
+        }
+    }
+}

--- a/crates/apps/addzero-lowcode/src/template.rs
+++ b/crates/apps/addzero-lowcode/src/template.rs
@@ -1,8 +1,18 @@
 /// Template management — save/load reusable layout templates (skeleton — to be fleshed out in #81).
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::schema::Template;
+use crate::schema::LayoutSchema;
+
+/// A reusable layout template (skeleton — will be fleshed out in #81).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Template {
+    pub id: Uuid,
+    pub name: String,
+    pub layout: LayoutSchema,
+    pub created_at: String,
+}
 
 /// Errors from template operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/apps/addzero-lowcode/src/template.rs
+++ b/crates/apps/addzero-lowcode/src/template.rs
@@ -1,0 +1,53 @@
+/// Template management — save/load reusable layout templates (skeleton — to be fleshed out in #81).
+
+use uuid::Uuid;
+
+use crate::schema::Template;
+
+/// Errors from template operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TemplateError {
+    #[error("template not found: {0}")]
+    NotFound(Uuid),
+    #[error("template validation failed: {0}")]
+    ValidationFailed(String),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+/// Template repository backed by PostgreSQL (skeleton).
+///
+/// The actual query implementations will be added alongside #81.
+pub struct TemplateRepo;
+
+impl TemplateRepo {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn create(&self, _tpl: &Template) -> Result<Template, TemplateError> {
+        todo!("template create — will be implemented in #81")
+    }
+
+    pub async fn get(&self, _id: Uuid) -> Result<Template, TemplateError> {
+        todo!("template get — will be implemented in #81")
+    }
+
+    pub async fn list(&self) -> Result<Vec<Template>, TemplateError> {
+        todo!("template list — will be implemented in #81")
+    }
+
+    pub async fn update(&self, _tpl: &Template) -> Result<Template, TemplateError> {
+        todo!("template update — will be implemented in #81")
+    }
+
+    pub async fn delete(&self, _id: Uuid) -> Result<(), TemplateError> {
+        todo!("template delete — will be implemented in #81")
+    }
+}
+
+impl Default for TemplateRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
Closes #76

## Summary

- Adds  type to  with backward-compatible  so existing JSON payloads (without /) still deserialize.
- Extends  with optional  and  fields.
- Implements full  in :
  -  constant (12).
  -  for CSS Grid position declarations.
  -  (and free-function ) generating complete CSS:
    -  root grid rule (, , , ).
    -  rules for each node, recursively including nested container grids.
    -  blocks for each breakpoint, applying to  and nested container selectors.
- Exports , , ,  from .

## Tests (7 new, 11 existing all pass)

| Test | What it covers |
|------|----------------|
|  | basic  output |
|  | varied col/row ranges |
|  | canvas + 2 nodes with gap/row height |
|  | tablet/mobile  blocks |
|  | parent with children as nested grid |
|  | no node rules when children empty |
|  | constant is 12 |

## Verification

```
cargo check -p addzero-lowcode   # ok
cargo test -p addzero-lowcode    # 18 passed, 0 failed
```
