### PR TITLE
feat(lowcode): #77 组件注册表 — 类型注册 + Props Schema 校验 + HTML 渲染

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addzero-lowcode"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "rhai",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "addzero-math"
 version = "0.1.0"
 dependencies = [
@@ -714,6 +729,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1452,6 +1481,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const-serialize"
@@ -5033,6 +5082,9 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -5450,6 +5502,12 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-pty"
@@ -6067,6 +6125,34 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rhai"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
+dependencies = [
+ "ahash",
+ "bitflags 2.11.1",
+ "num-traits",
+ "once_cell",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+ "thin-vec",
+ "web-time",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4322a2a4e8cf30771dd9f27f7f37ca9ac8fe812dddd811096a98483080dabe6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6971,6 +7057,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7539,6 +7636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7616,6 +7719,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/storage/*",
     "crates/text/*",
     "crates/ui/*",
+    "crates/apps/addzero-lowcode",
 ]
 exclude = ["apps/remote-desktop"]
 
@@ -67,6 +68,7 @@ sea-orm = { version = "1.1.20", default-features = false, features = ["macros", 
 sea-orm-migration = { version = "1.1.20", default-features = false, features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 futures-util = "0.3.31"
 quinn = { version = "0.11.9", default-features = false, features = ["runtime-tokio", "rustls"] }
+axum = { version = "0.8.6", features = ["http1", "json", "tokio", "ws"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/apps/addzero-lowcode/Cargo.toml
+++ b/crates/apps/addzero-lowcode/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "addzero-lowcode"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+axum = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+sqlx = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+rhai = "1.20"
+
+[lints]
+workspace = true

--- a/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
+++ b/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
@@ -1,50 +1,44 @@
--- Lowcode service — initial schema
--- Tables follow the all-in-pg convention.
+-- Lowcode service — initial schema (issue #75)
+-- Tables follow the all-in-pg convention with lc_ prefix.
 
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- ---------------------------------------------------------------------------
--- layouts: top-level container of component nodes
+-- lc_layout: top-level container with JSONB schema + optimistic versioning
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS lowcode_layouts (
+CREATE TABLE IF NOT EXISTS lc_layout (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name        TEXT NOT NULL,
-    nodes       JSONB NOT NULL DEFAULT '[]'::jsonb,
+    schema      JSONB NOT NULL,
+    version     INT NOT NULL DEFAULT 1,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- ---------------------------------------------------------------------------
--- component_defs: registered component type metadata
+-- lc_component: registered component type metadata
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS lowcode_component_defs (
-    type_name    TEXT PRIMARY KEY,
-    props_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
-    category     TEXT NOT NULL DEFAULT 'general',
-    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS lc_component (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    type_key      TEXT NOT NULL UNIQUE,
+    props_schema  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    category      TEXT NOT NULL DEFAULT 'basic',
+    icon          TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- ---------------------------------------------------------------------------
--- templates: reusable layout templates
+-- lc_event_binding: bindings that connect component events to handlers
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS lowcode_templates (
-    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name       TEXT NOT NULL,
-    layout     JSONB NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS lc_event_binding (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    layout_id        UUID NOT NULL REFERENCES lc_layout(id) ON DELETE CASCADE,
+    component_path   TEXT NOT NULL,
+    event_type       TEXT NOT NULL,
+    handler_type     TEXT NOT NULL,
+    handler_config   JSONB NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- ---------------------------------------------------------------------------
--- event_bindings: bindings that connect component events to handlers
--- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS lowcode_event_bindings (
-    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    layout_id    UUID NOT NULL REFERENCES lowcode_layouts(id) ON DELETE CASCADE,
-    node_id      UUID NOT NULL,
-    event_name   TEXT NOT NULL,
-    handler      JSONB NOT NULL,
-    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_event_bindings_layout
-    ON lowcode_event_bindings(layout_id);
+CREATE INDEX IF NOT EXISTS idx_event_binding_layout
+    ON lc_event_binding(layout_id);

--- a/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
+++ b/crates/apps/addzero-lowcode/migrations/001_init_lowcode.sql
@@ -1,0 +1,50 @@
+-- Lowcode service — initial schema
+-- Tables follow the all-in-pg convention.
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- layouts: top-level container of component nodes
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_layouts (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL,
+    nodes       JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- component_defs: registered component type metadata
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_component_defs (
+    type_name    TEXT PRIMARY KEY,
+    props_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
+    category     TEXT NOT NULL DEFAULT 'general',
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- templates: reusable layout templates
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_templates (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name       TEXT NOT NULL,
+    layout     JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- event_bindings: bindings that connect component events to handlers
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lowcode_event_bindings (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    layout_id    UUID NOT NULL REFERENCES lowcode_layouts(id) ON DELETE CASCADE,
+    node_id      UUID NOT NULL,
+    event_name   TEXT NOT NULL,
+    handler      JSONB NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_bindings_layout
+    ON lowcode_event_bindings(layout_id);

--- a/crates/apps/addzero-lowcode/src/editor.rs
+++ b/crates/apps/addzero-lowcode/src/editor.rs
@@ -1,0 +1,14 @@
+/// Canvas editor operations (skeleton — to be implemented in #78).
+pub struct CanvasEditor;
+
+impl CanvasEditor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CanvasEditor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/events.rs
+++ b/crates/apps/addzero-lowcode/src/events.rs
@@ -1,0 +1,15 @@
+/// Event system and handler registry (skeleton — to be implemented in #79).
+#[derive(Clone)]
+pub struct HandlerRegistry;
+
+impl HandlerRegistry {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HandlerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/grid.rs
+++ b/crates/apps/addzero-lowcode/src/grid.rs
@@ -1,0 +1,14 @@
+/// Grid-based layout engine (skeleton — to be implemented in #76).
+pub struct GridEngine;
+
+impl GridEngine {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for GridEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/lib.rs
+++ b/crates/apps/addzero-lowcode/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod schema;
+pub mod grid;
+pub mod registry;
+pub mod editor;
+pub mod events;
+pub mod scripting;
+pub mod render;
+pub mod template;
+pub mod repo;
+pub mod router;
+pub mod state;
+
+pub use router::lowcode_router;
+pub use state::LowcodeState;

--- a/crates/apps/addzero-lowcode/src/lib.rs
+++ b/crates/apps/addzero-lowcode/src/lib.rs
@@ -1,23 +1,26 @@
-pub mod schema;
-pub mod grid;
-pub mod registry;
 pub mod editor;
 pub mod events;
-pub mod scripting;
+pub mod grid;
+pub mod registry;
 pub mod render;
-pub mod template;
 pub mod repo;
 pub mod router;
+pub mod schema;
+pub mod scripting;
 pub mod state;
+pub mod template;
 
 // Re-export core schema types
 pub use schema::{
-    ComponentDefRecord, ComponentNode, EventBindingRecord, GridArea, GridDefinition,
-    HandlerType, LayoutSchema,
+    ComponentDefRecord, ComponentNode, EventBindingRecord, GridArea, GridDefinition, HandlerType,
+    LayoutSchema,
 };
 
 // Re-export repository trait and record
 pub use repo::{LayoutRecord, LayoutRepository, PgLayoutRepo, RepoError};
+
+// Re-export registry types
+pub use registry::{ComponentEntry, ComponentInfo, ComponentRegistry, RegistryError};
 
 pub use router::lowcode_router;
 pub use state::LowcodeState;

--- a/crates/apps/addzero-lowcode/src/lib.rs
+++ b/crates/apps/addzero-lowcode/src/lib.rs
@@ -10,5 +10,14 @@ pub mod repo;
 pub mod router;
 pub mod state;
 
+// Re-export core schema types
+pub use schema::{
+    ComponentDefRecord, ComponentNode, EventBindingRecord, GridArea, GridDefinition,
+    HandlerType, LayoutSchema,
+};
+
+// Re-export repository trait and record
+pub use repo::{LayoutRecord, LayoutRepository, PgLayoutRepo, RepoError};
+
 pub use router::lowcode_router;
 pub use state::LowcodeState;

--- a/crates/apps/addzero-lowcode/src/registry.rs
+++ b/crates/apps/addzero-lowcode/src/registry.rs
@@ -1,38 +1,725 @@
+//! Component registry — runtime type registration, props validation, and rendering.
+//!
+//! Manages `ComponentEntry` objects that pair a JSON Schema definition with a
+//! renderer closure. Ships with 8 built-in component types (button, input, text,
+//! container, table, form, image, divider).
+
 use std::collections::HashMap;
+use std::fmt;
 
-use crate::schema::ComponentDefRecord;
+use serde::{Deserialize, Serialize};
 
-/// In-memory component type registry (skeleton — to be fleshed out in #77).
-#[derive(Clone)]
+use crate::schema::{ComponentDefRecord, ComponentNode};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Closure that renders a `ComponentNode` to an HTML string.
+pub type ComponentRenderer = Box<dyn Fn(&ComponentNode) -> String + Send + Sync>;
+
+/// Runtime entry for a registered component type.
+///
+/// Combines metadata (type key, category) with a JSON Schema describing
+/// accepted props and a renderer closure that produces HTML output.
+pub struct ComponentEntry {
+    pub type_key: String,
+    pub category: String,
+    pub props_schema: serde_json::Value,
+    pub renderer: ComponentRenderer,
+}
+
+/// Errors returned by the component registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryError(pub Vec<String>);
+
+impl fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "registry errors: {}", self.0.join("; "))
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+/// Lightweight JSON view returned by the list API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentInfo {
+    pub type_key: String,
+    pub category: String,
+    pub props_schema: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// ComponentRegistry
+// ---------------------------------------------------------------------------
+
+/// In-memory component type registry.
+///
+/// Stores `ComponentEntry` instances keyed by `type_key`. Supports CRUD
+/// operations, JSON Schema prop validation, and node rendering.
 pub struct ComponentRegistry {
-    components: HashMap<String, ComponentDefRecord>,
+    entries: HashMap<String, ComponentEntry>,
 }
 
 impl ComponentRegistry {
     pub fn new() -> Self {
         Self {
-            components: HashMap::new(),
+            entries: HashMap::new(),
         }
     }
 
-    /// Register a new component definition.
-    pub fn register(&mut self, def: ComponentDefRecord) {
-        self.components.insert(def.type_key.clone(), def);
+    /// Register a runtime component entry.
+    pub fn register(&mut self, entry: ComponentEntry) {
+        self.entries.insert(entry.type_key.clone(), entry);
     }
 
-    /// Look up a component by type key.
-    pub fn get(&self, type_key: &str) -> Option<&ComponentDefRecord> {
-        self.components.get(type_key)
+    /// Create a `ComponentEntry` from a persisted DB record and register it.
+    pub fn register_from_record(
+        &mut self,
+        record: ComponentDefRecord,
+        renderer: ComponentRenderer,
+    ) {
+        let entry = ComponentEntry {
+            type_key: record.type_key,
+            category: record.category,
+            props_schema: record.props_schema,
+            renderer,
+        };
+        self.entries.insert(entry.type_key.clone(), entry);
     }
 
-    /// List all registered component definitions.
-    pub fn list(&self) -> Vec<&ComponentDefRecord> {
-        self.components.values().collect()
+    /// Remove a component type. Returns `true` if it existed.
+    pub fn unregister(&mut self, type_key: &str) -> bool {
+        self.entries.remove(type_key).is_some()
+    }
+
+    /// Look up a component entry by type key.
+    pub fn get_entry(&self, type_key: &str) -> Option<&ComponentEntry> {
+        self.entries.get(type_key)
+    }
+
+    /// Alias for `get_entry` (backward compatibility).
+    pub fn get(&self, type_key: &str) -> Option<&ComponentEntry> {
+        self.get_entry(type_key)
+    }
+
+    /// List all registered entries.
+    pub fn list(&self) -> Vec<&ComponentEntry> {
+        self.entries.values().collect()
+    }
+
+    /// List entries filtered by category.
+    pub fn list_by_category(&self, category: &str) -> Vec<&ComponentEntry> {
+        self.entries
+            .values()
+            .filter(|e| e.category == category)
+            .collect()
+    }
+
+    /// Collect distinct categories (unsorted).
+    pub fn categories(&self) -> Vec<String> {
+        let mut cats: Vec<String> = self
+            .entries
+            .values()
+            .map(|e| e.category.clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        cats.sort();
+        cats
+    }
+
+    /// Return lightweight info for every registered entry (used by the API).
+    pub fn list_info(&self) -> Vec<ComponentInfo> {
+        self.entries
+            .values()
+            .map(|e| ComponentInfo {
+                type_key: e.type_key.clone(),
+                category: e.category.clone(),
+                props_schema: e.props_schema.clone(),
+            })
+            .collect()
+    }
+
+    /// Validate `props` against the JSON Schema stored for `type_key`.
+    ///
+    /// Returns `Ok(())` on success, or `Err(Vec<String>)` with one message per
+    /// validation failure. Supported checks:
+    /// - **required** fields are present
+    /// - basic **type** matching (string / number / boolean / array / object)
+    pub fn validate_props(
+        &self,
+        type_key: &str,
+        props: &serde_json::Value,
+    ) -> Result<(), Vec<String>> {
+        let entry = self
+            .entries
+            .get(type_key)
+            .ok_or_else(|| vec![format!("unknown component type: {type_key}")])?;
+
+        let schema = &entry.props_schema;
+        let mut errors = Vec::new();
+
+        // Collect required fields
+        if let Some(required) = schema.get("required").and_then(|v| v.as_array()) {
+            for field in required {
+                if let Some(name) = field.as_str() {
+                    if props.get(name).is_none() || props.get(name).unwrap().is_null() {
+                        errors.push(format!("missing required field: {name}"));
+                    }
+                }
+            }
+        }
+
+        // Type-check each declared property
+        if let Some(properties) = schema.get("properties").and_then(|v| v.as_object()) {
+            for (field_name, field_schema) in properties {
+                if let Some(value) = props.get(field_name) {
+                    if value.is_null() {
+                        continue; // null is allowed for optional fields
+                    }
+                    if let Some(expected_type) = field_schema.get("type").and_then(|v| v.as_str()) {
+                        let ok = match expected_type {
+                            "string" => value.is_string(),
+                            "number" => value.is_number(),
+                            "integer" => value.is_i64() || value.is_u64(),
+                            "boolean" => value.is_boolean(),
+                            "array" => value.is_array(),
+                            "object" => value.is_object(),
+                            _ => true, // unknown types pass
+                        };
+                        if !ok {
+                            errors.push(format!(
+                                "field '{field_name}': expected {expected_type}, got {}",
+                                json_type_name(value),
+                            ));
+                        }
+                    }
+
+                    // Enum validation
+                    if let Some(enum_vals) = field_schema.get("enum").and_then(|v| v.as_array()) {
+                        if !enum_vals.contains(value) {
+                            errors.push(format!(
+                                "field '{field_name}': value {value} not in enum {:?}",
+                                enum_vals,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    /// Render a component node to HTML by looking up its type and invoking the
+    /// registered renderer.
+    pub fn render(&self, node: &ComponentNode) -> Result<String, String> {
+        let entry = self
+            .entries
+            .get(&node.type_key)
+            .ok_or_else(|| format!("unknown component type: {}", node.type_key))?;
+        Ok((entry.renderer)(node))
+    }
+
+    /// Create a registry pre-loaded with the 8 built-in component types.
+    pub fn with_builtins() -> Self {
+        let mut reg = Self::new();
+        register_builtins(&mut reg);
+        reg
     }
 }
 
 impl Default for ComponentRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn json_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Extract a string prop, falling back to `default`.
+fn str_prop(props: &serde_json::Value, key: &str, default: &str) -> String {
+    props
+        .get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or(default)
+        .to_string()
+}
+
+/// Extract a boolean prop, falling back to `default`.
+fn bool_prop(props: &serde_json::Value, key: &str, default: bool) -> bool {
+    props.get(key).and_then(|v| v.as_bool()).unwrap_or(default)
+}
+
+/// Register the 8 built-in component types.
+fn register_builtins(reg: &mut ComponentRegistry) {
+    // ---- button ----
+    reg.register(ComponentEntry {
+        type_key: "button".into(),
+        category: "basic".into(),
+        props_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "label":    { "type": "string" },
+                "variant":  { "type": "string", "enum": ["primary", "secondary", "danger"], "default": "primary" },
+                "disabled": { "type": "boolean", "default": false }
+            },
+            "required": ["label"]
+        }),
+        renderer: Box::new(|node| {
+            let p = &node.props;
+            let label = str_prop(p, "label", "");
+            let variant = str_prop(p, "variant", "primary");
+            let disabled = bool_prop(p, "disabled", false);
+            let dis_attr = if disabled { " disabled" } else { "" };
+            format!(
+                r#"<button class="lc-button lc-button--{variant}"{dis_attr}>{label}</button>"#
+            )
+        }),
+    });
+
+    // ---- input ----
+    reg.register(ComponentEntry {
+        type_key: "input".into(),
+        category: "basic".into(),
+        props_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "placeholder": { "type": "string" },
+                "input_type":  { "type": "string", "enum": ["text", "email", "password", "number"], "default": "text" },
+                "required":    { "type": "boolean" }
+            },
+            "required": []
+        }),
+        renderer: Box::new(|node| {
+            let p = &node.props;
+            let placeholder = str_prop(p, "placeholder", "");
+            let input_type = str_prop(p, "input_type", "text");
+            let required = bool_prop(p, "required", false);
+            let req_attr = if required { " required" } else { "" };
+            format!(
+                r#"<input type="{input_type}" placeholder="{placeholder}"{req_attr} />"#
+            )
+        }),
+    });
+
+    // ---- text ----
+    reg.register(ComponentEntry {
+        type_key: "text".into(),
+        category: "basic".into(),
+        props_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "content": { "type": "string" },
+                "tag":     { "type": "string", "enum": ["p", "h1", "h2", "h3", "h4", "span"], "default": "p" },
+                "align":   { "type": "string", "enum": ["left", "center", "right"], "default": "left" }
+            },
+            "required": ["content"]
+        }),
+        renderer: Box::new(|node| {
+            let p = &node.props;
+            let content = str_prop(p, "content", "");
+            let tag = str_prop(p, "tag", "p");
+            let align = str_prop(p, "align", "left");
+            format!(
+                r#"<{tag} style="text-align:{align}">{content}</{tag}>"#
+            )
+        }),
+    });
+
+    // ---- container ----
+    reg.register(ComponentEntry {
+        type_key: "container".into(),
+        category: "layout".into(),
+        props_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "direction": { "type": "string", "enum": ["row", "column"], "default": "column" },
+                "padding":   { "type": "string" }
+            },
+            "required": []
+        }),
+        renderer: Box::new(|node| {
+            let p = &node.props;
+            let direction = str_prop(p, "direction", "column");
+            let padding = str_prop(p, "padding", "0");
+            let children_html = node
+                .children
+                .iter()
+                .map(|child| {
+                    // Inline mini-render: produce a placeholder for children
+                    // that aren't rendered through the full registry path.
+                    format!(
+                        r#"<div class="lc-child" data-id="{}">{}</div>"#,
+                        child.id, child.props
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!(
+                r#"<div class="lc-container" style="display:flex;flex-direction:{direction};padding:{padding}">{children_html}</div>"#
+            )
+        }),
+    });
+
+    // ---- table ----
+    reg.register(ComponentEntry {
+        type_key: "table".into(),
+        category: "data".into(),
+        props_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "columns":     { "type": "array" },
+                "data_source": { "type": "string" },
+                "pagination":  { "type": "boolean" }
+            },
+            "required": ["columns"]
+        }),
+        renderer: Box::new(|node| {
+            let p = &node.props;
+            let columns = p
+                .get("columns")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let header_cells = columns
+                .iter()
+                .map(|col| {
+                    let label = col
+                        .get("label")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    format!("<th>{label}</th>")
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            let _data_source = str_prop(p, "data_source", "");
+            let _pagination = bool_prop(p, "pagination", false);
+            format!(
+                r#"<table class="lc-table"><thead><tr>{header_cells}</tr></thead><tbody></tbody></table>"#
+            )
+        }),
+    });
+
+    // ---- form ----
+    reg.register(ComponentEntry {
+        type_key: "form".into(),
+        category: "layout".into(),
+        props_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "action": { "type": "string" },
+                "method": { "type": "string", "enum": ["GET", "POST"] },
+                "fields": { "type": "array" }
+            },
+            "required": []
+        }),
+        renderer: Box::new(|node| {
+            let p = &node.props;
+            let action = str_prop(p, "action", "");
+            let method = str_prop(p, "method", "POST");
+            let children_html = node
+                .children
+                .iter()
+                .map(|child| format!(r#"<div class="lc-field">{}</div>"#, child.props))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!(r#"<form action="{action}" method="{method}">{children_html}</form>"#)
+        }),
+    });
+
+    // ---- image ----
+    reg.register(ComponentEntry {
+        type_key: "image".into(),
+        category: "media".into(),
+        props_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "src":       { "type": "string" },
+                "alt":       { "type": "string" },
+                "object_fit": { "type": "string", "enum": ["cover", "contain", "fill"] }
+            },
+            "required": ["src"]
+        }),
+        renderer: Box::new(|node| {
+            let p = &node.props;
+            let src = str_prop(p, "src", "");
+            let alt = str_prop(p, "alt", "");
+            let object_fit = str_prop(p, "object_fit", "cover");
+            format!(r#"<img src="{src}" alt="{alt}" style="object-fit:{object_fit}" />"#)
+        }),
+    });
+
+    // ---- divider ----
+    reg.register(ComponentEntry {
+        type_key: "divider".into(),
+        category: "basic".into(),
+        props_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "orientation": { "type": "string", "enum": ["horizontal", "vertical"], "default": "horizontal" }
+            },
+            "required": []
+        }),
+        renderer: Box::new(|node| {
+            let orientation = str_prop(&node.props, "orientation", "horizontal");
+            format!(
+                r#"<hr class="lc-divider lc-divider--{orientation}" />"#
+            )
+        }),
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_node(type_key: &str, props: serde_json::Value) -> ComponentNode {
+        ComponentNode {
+            id: "test-node".into(),
+            type_key: type_key.into(),
+            props,
+            grid_area: crate::schema::GridArea {
+                col_start: 1,
+                col_end: 2,
+                row_start: 1,
+                row_end: 2,
+            },
+            children: vec![],
+        }
+    }
+
+    #[test]
+    fn test_with_builtins_has_8_components() {
+        let reg = ComponentRegistry::with_builtins();
+        assert_eq!(reg.list().len(), 8);
+    }
+
+    #[test]
+    fn test_all_builtins_have_renderer() {
+        let reg = ComponentRegistry::with_builtins();
+        for entry in reg.list() {
+            let node = make_node(&entry.type_key, serde_json::json!({}));
+            // Should not panic — every built-in renderer handles empty props
+            let _html = (entry.renderer)(&node);
+        }
+    }
+
+    #[test]
+    fn test_register_and_get() {
+        let mut reg = ComponentRegistry::new();
+        reg.register(ComponentEntry {
+            type_key: "custom".into(),
+            category: "test".into(),
+            props_schema: serde_json::json!({}),
+            renderer: Box::new(|_| "<custom/>".into()),
+        });
+        assert!(reg.get("custom").is_some());
+        assert_eq!(reg.get("custom").unwrap().category, "test");
+    }
+
+    #[test]
+    fn test_unregister() {
+        let mut reg = ComponentRegistry::with_builtins();
+        assert!(reg.unregister("button"));
+        assert!(!reg.unregister("button"));
+        assert!(reg.get("button").is_none());
+    }
+
+    #[test]
+    fn test_list_by_category() {
+        let reg = ComponentRegistry::with_builtins();
+        let basics = reg.list_by_category("basic");
+        // button, input, text, divider = 4 basic components
+        assert_eq!(basics.len(), 4);
+        let layouts = reg.list_by_category("layout");
+        assert_eq!(layouts.len(), 2); // container, form
+    }
+
+    #[test]
+    fn test_validate_props_success() {
+        let reg = ComponentRegistry::with_builtins();
+        let props = serde_json::json!({ "label": "Click me" });
+        assert!(reg.validate_props("button", &props).is_ok());
+    }
+
+    #[test]
+    fn test_validate_props_missing_required() {
+        let reg = ComponentRegistry::with_builtins();
+        let props = serde_json::json!({});
+        let result = reg.validate_props("button", &props);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("label")));
+    }
+
+    #[test]
+    fn test_validate_props_wrong_type() {
+        let reg = ComponentRegistry::with_builtins();
+        let props = serde_json::json!({ "label": 123 });
+        let result = reg.validate_props("button", &props);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("expected string")));
+    }
+
+    #[test]
+    fn test_validate_props_enum() {
+        let reg = ComponentRegistry::with_builtins();
+        let props = serde_json::json!({ "label": "OK", "variant": "invalid" });
+        let result = reg.validate_props("button", &props);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("not in enum")));
+    }
+
+    #[test]
+    fn test_validate_unknown_type() {
+        let reg = ComponentRegistry::with_builtins();
+        let result = reg.validate_props("nonexistent", &serde_json::json!({}));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_render_button() {
+        let reg = ComponentRegistry::with_builtins();
+        let node = make_node("button", serde_json::json!({ "label": "Go" }));
+        let html = reg.render(&node).unwrap();
+        assert!(html.contains("<button"));
+        assert!(html.contains("Go"));
+        assert!(html.contains("lc-button--primary"));
+    }
+
+    #[test]
+    fn test_render_button_disabled() {
+        let reg = ComponentRegistry::with_builtins();
+        let node = make_node(
+            "button",
+            serde_json::json!({ "label": "Off", "disabled": true }),
+        );
+        let html = reg.render(&node).unwrap();
+        assert!(html.contains("disabled"));
+    }
+
+    #[test]
+    fn test_render_text() {
+        let reg = ComponentRegistry::with_builtins();
+        let node = make_node(
+            "text",
+            serde_json::json!({ "content": "Hello", "tag": "h2", "align": "center" }),
+        );
+        let html = reg.render(&node).unwrap();
+        assert!(html.contains("<h2"));
+        assert!(html.contains("Hello"));
+        assert!(html.contains("text-align:center"));
+    }
+
+    #[test]
+    fn test_render_container_with_children() {
+        let reg = ComponentRegistry::with_builtins();
+        let child = ComponentNode {
+            id: "c1".into(),
+            type_key: "text".into(),
+            props: serde_json::json!({ "content": "inner" }),
+            grid_area: crate::schema::GridArea {
+                col_start: 1,
+                col_end: 2,
+                row_start: 1,
+                row_end: 2,
+            },
+            children: vec![],
+        };
+        let node = ComponentNode {
+            id: "root".into(),
+            type_key: "container".into(),
+            props: serde_json::json!({ "direction": "row", "padding": "8px" }),
+            grid_area: crate::schema::GridArea {
+                col_start: 1,
+                col_end: 4,
+                row_start: 1,
+                row_end: 4,
+            },
+            children: vec![child],
+        };
+        let html = reg.render(&node).unwrap();
+        assert!(html.contains("flex-direction:row"));
+        assert!(html.contains("padding:8px"));
+        assert!(html.contains("lc-child"));
+    }
+
+    #[test]
+    fn test_render_image() {
+        let reg = ComponentRegistry::with_builtins();
+        let node = make_node(
+            "image",
+            serde_json::json!({ "src": "/logo.png", "alt": "Logo" }),
+        );
+        let html = reg.render(&node).unwrap();
+        assert!(html.contains(r#"src="/logo.png""#));
+        assert!(html.contains(r#"alt="Logo""#));
+    }
+
+    #[test]
+    fn test_render_divider() {
+        let reg = ComponentRegistry::with_builtins();
+        let node = make_node("divider", serde_json::json!({}));
+        let html = reg.render(&node).unwrap();
+        assert!(html.contains("<hr"));
+        assert!(html.contains("horizontal"));
+    }
+
+    #[test]
+    fn test_render_unknown_type() {
+        let reg = ComponentRegistry::with_builtins();
+        let node = make_node("nonexistent", serde_json::json!({}));
+        assert!(reg.render(&node).is_err());
+    }
+
+    #[test]
+    fn test_categories() {
+        let reg = ComponentRegistry::with_builtins();
+        let cats = reg.categories();
+        assert!(cats.contains(&"basic".into()));
+        assert!(cats.contains(&"layout".into()));
+        assert!(cats.contains(&"data".into()));
+        assert!(cats.contains(&"media".into()));
+    }
+
+    #[test]
+    fn test_register_from_record() {
+        let mut reg = ComponentRegistry::new();
+        let record = ComponentDefRecord {
+            id: uuid::Uuid::nil(),
+            type_key: "my_widget".into(),
+            props_schema: serde_json::json!({ "properties": {} }),
+            category: "custom".into(),
+            icon: None,
+            created_at: "2025-01-01T00:00:00Z".into(),
+        };
+        reg.register_from_record(record, Box::new(|_| "<widget/>".into()));
+        assert!(reg.get("my_widget").is_some());
+        assert_eq!(reg.get("my_widget").unwrap().category, "custom");
     }
 }

--- a/crates/apps/addzero-lowcode/src/registry.rs
+++ b/crates/apps/addzero-lowcode/src/registry.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+use crate::schema::ComponentDef;
+
+/// In-memory component type registry (skeleton — to be fleshed out in #77).
+#[derive(Clone)]
+pub struct ComponentRegistry {
+    components: HashMap<String, ComponentDef>,
+}
+
+impl ComponentRegistry {
+    pub fn new() -> Self {
+        Self {
+            components: HashMap::new(),
+        }
+    }
+
+    /// Register a new component definition.
+    pub fn register(&mut self, def: ComponentDef) {
+        self.components.insert(def.type_name.clone(), def);
+    }
+
+    /// Look up a component by type name.
+    pub fn get(&self, type_name: &str) -> Option<&ComponentDef> {
+        self.components.get(type_name)
+    }
+
+    /// List all registered component definitions.
+    pub fn list(&self) -> Vec<&ComponentDef> {
+        self.components.values().collect()
+    }
+}
+
+impl Default for ComponentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/registry.rs
+++ b/crates/apps/addzero-lowcode/src/registry.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use crate::schema::ComponentDef;
+use crate::schema::ComponentDefRecord;
 
 /// In-memory component type registry (skeleton — to be fleshed out in #77).
 #[derive(Clone)]
 pub struct ComponentRegistry {
-    components: HashMap<String, ComponentDef>,
+    components: HashMap<String, ComponentDefRecord>,
 }
 
 impl ComponentRegistry {
@@ -16,17 +16,17 @@ impl ComponentRegistry {
     }
 
     /// Register a new component definition.
-    pub fn register(&mut self, def: ComponentDef) {
-        self.components.insert(def.type_name.clone(), def);
+    pub fn register(&mut self, def: ComponentDefRecord) {
+        self.components.insert(def.type_key.clone(), def);
     }
 
-    /// Look up a component by type name.
-    pub fn get(&self, type_name: &str) -> Option<&ComponentDef> {
-        self.components.get(type_name)
+    /// Look up a component by type key.
+    pub fn get(&self, type_key: &str) -> Option<&ComponentDefRecord> {
+        self.components.get(type_key)
     }
 
     /// List all registered component definitions.
-    pub fn list(&self) -> Vec<&ComponentDef> {
+    pub fn list(&self) -> Vec<&ComponentDefRecord> {
         self.components.values().collect()
     }
 }

--- a/crates/apps/addzero-lowcode/src/render.rs
+++ b/crates/apps/addzero-lowcode/src/render.rs
@@ -1,6 +1,6 @@
 /// Render pipeline — converts a layout tree into output (skeleton — to be implemented in #81).
 
-use crate::schema::Layout;
+use crate::schema::LayoutSchema;
 
 /// Errors that can occur during rendering.
 #[derive(Debug, thiserror::Error)]
@@ -22,7 +22,6 @@ pub struct RenderOutput {
 /// Renders a layout into a preview-ready output.
 ///
 /// The actual rendering logic will be fleshed out in #81.
-pub fn render(layout: &Layout) -> Result<RenderOutput, RenderError> {
-    let _ = layout;
+pub fn render(_layout: &LayoutSchema) -> Result<RenderOutput, RenderError> {
     todo!("render pipeline — will be implemented in #81")
 }

--- a/crates/apps/addzero-lowcode/src/render.rs
+++ b/crates/apps/addzero-lowcode/src/render.rs
@@ -1,0 +1,28 @@
+/// Render pipeline — converts a layout tree into output (skeleton — to be implemented in #81).
+
+use crate::schema::Layout;
+
+/// Errors that can occur during rendering.
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    #[error("layout not found: {0}")]
+    LayoutNotFound(uuid::Uuid),
+    #[error("unsupported component type: {0}")]
+    UnsupportedComponent(String),
+    #[error("render pipeline error: {0}")]
+    Pipeline(String),
+}
+
+/// Placeholder render result.
+#[derive(Debug, Clone)]
+pub struct RenderOutput {
+    pub html: String,
+}
+
+/// Renders a layout into a preview-ready output.
+///
+/// The actual rendering logic will be fleshed out in #81.
+pub fn render(layout: &Layout) -> Result<RenderOutput, RenderError> {
+    let _ = layout;
+    todo!("render pipeline — will be implemented in #81")
+}

--- a/crates/apps/addzero-lowcode/src/repo.rs
+++ b/crates/apps/addzero-lowcode/src/repo.rs
@@ -1,8 +1,14 @@
-/// PG repository for lowcode layouts (skeleton — to be fleshed out in subsequent issues).
+//! CRUD repository trait + PG implementation for lowcode layouts.
 
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::schema::Layout;
+use crate::schema::LayoutSchema;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
 
 /// Errors from layout repository operations.
 #[derive(Debug, thiserror::Error)]
@@ -13,39 +19,91 @@ pub enum RepoError {
     Database(#[from] sqlx::Error),
 }
 
-/// Layout repository backed by PostgreSQL (skeleton).
+// ---------------------------------------------------------------------------
+// Persisted record — the row-level shape stored in PG `lc_layout`
+// ---------------------------------------------------------------------------
+
+/// A layout row as stored in / read from PostgreSQL.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutRecord {
+    pub id: Uuid,
+    pub name: String,
+    pub schema: LayoutSchema,
+    pub version: i32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Repository trait
+// ---------------------------------------------------------------------------
+
+/// CRUD operations for lowcode layouts.
+#[async_trait]
+pub trait LayoutRepository: Send + Sync {
+    /// Insert a new layout and return the created record.
+    async fn create(&self, name: &str, schema: &LayoutSchema) -> Result<LayoutRecord, RepoError>;
+
+    /// Get a layout by id.
+    async fn get(&self, id: Uuid) -> Result<LayoutRecord, RepoError>;
+
+    /// List all layouts.
+    async fn list(&self) -> Result<Vec<LayoutRecord>, RepoError>;
+
+    /// Update layout name and/or schema. Returns the updated record.
+    async fn update(
+        &self,
+        id: Uuid,
+        name: &str,
+        schema: &LayoutSchema,
+    ) -> Result<LayoutRecord, RepoError>;
+
+    /// Delete a layout by id.
+    async fn delete(&self, id: Uuid) -> Result<(), RepoError>;
+}
+
+// ---------------------------------------------------------------------------
+// PG implementation (queries will be wired up once PG is connected)
+// ---------------------------------------------------------------------------
+
+/// PostgreSQL-backed layout repository.
 ///
-/// The actual query implementations will be added alongside issues #75–#81.
-pub struct LayoutRepo;
+/// Query bodies are `todo!()` stubs — they will be filled in when the PG
+/// connection is wired up. The trait signatures are final.
+pub struct PgLayoutRepo {
+    _pool: sqlx::PgPool,
+}
 
-impl LayoutRepo {
-    pub fn new() -> Self {
-        Self
-    }
-
-    pub async fn create(&self, _layout: &Layout) -> Result<Layout, RepoError> {
-        todo!("layout create — will be implemented in #75")
-    }
-
-    pub async fn get(&self, _id: Uuid) -> Result<Layout, RepoError> {
-        todo!("layout get — will be implemented in #75")
-    }
-
-    pub async fn list(&self) -> Result<Vec<Layout>, RepoError> {
-        todo!("layout list — will be implemented in #75")
-    }
-
-    pub async fn update(&self, _layout: &Layout) -> Result<Layout, RepoError> {
-        todo!("layout update — will be implemented in #75")
-    }
-
-    pub async fn delete(&self, _id: Uuid) -> Result<(), RepoError> {
-        todo!("layout delete — will be implemented in #75")
+impl PgLayoutRepo {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { _pool: pool }
     }
 }
 
-impl Default for LayoutRepo {
-    fn default() -> Self {
-        Self::new()
+#[async_trait]
+impl LayoutRepository for PgLayoutRepo {
+    async fn create(&self, _name: &str, _schema: &LayoutSchema) -> Result<LayoutRecord, RepoError> {
+        todo!("PG create layout — will be wired to real queries")
+    }
+
+    async fn get(&self, _id: Uuid) -> Result<LayoutRecord, RepoError> {
+        todo!("PG get layout — will be wired to real queries")
+    }
+
+    async fn list(&self) -> Result<Vec<LayoutRecord>, RepoError> {
+        todo!("PG list layouts — will be wired to real queries")
+    }
+
+    async fn update(
+        &self,
+        _id: Uuid,
+        _name: &str,
+        _schema: &LayoutSchema,
+    ) -> Result<LayoutRecord, RepoError> {
+        todo!("PG update layout — will be wired to real queries")
+    }
+
+    async fn delete(&self, _id: Uuid) -> Result<(), RepoError> {
+        todo!("PG delete layout — will be wired to real queries")
     }
 }

--- a/crates/apps/addzero-lowcode/src/repo.rs
+++ b/crates/apps/addzero-lowcode/src/repo.rs
@@ -1,0 +1,51 @@
+/// PG repository for lowcode layouts (skeleton — to be fleshed out in subsequent issues).
+
+use uuid::Uuid;
+
+use crate::schema::Layout;
+
+/// Errors from layout repository operations.
+#[derive(Debug, thiserror::Error)]
+pub enum RepoError {
+    #[error("layout not found: {0}")]
+    NotFound(Uuid),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+/// Layout repository backed by PostgreSQL (skeleton).
+///
+/// The actual query implementations will be added alongside issues #75–#81.
+pub struct LayoutRepo;
+
+impl LayoutRepo {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn create(&self, _layout: &Layout) -> Result<Layout, RepoError> {
+        todo!("layout create — will be implemented in #75")
+    }
+
+    pub async fn get(&self, _id: Uuid) -> Result<Layout, RepoError> {
+        todo!("layout get — will be implemented in #75")
+    }
+
+    pub async fn list(&self) -> Result<Vec<Layout>, RepoError> {
+        todo!("layout list — will be implemented in #75")
+    }
+
+    pub async fn update(&self, _layout: &Layout) -> Result<Layout, RepoError> {
+        todo!("layout update — will be implemented in #75")
+    }
+
+    pub async fn delete(&self, _id: Uuid) -> Result<(), RepoError> {
+        todo!("layout delete — will be implemented in #75")
+    }
+}
+
+impl Default for LayoutRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/router.rs
+++ b/crates/apps/addzero-lowcode/src/router.rs
@@ -1,5 +1,4 @@
 /// Axum router for the lowcode service.
-
 use axum::{
     Router,
     extract::{Path, State},
@@ -110,15 +109,56 @@ async fn delete_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl I
 }
 
 // ---------------------------------------------------------------------------
-// Component registry (skeleton — #77)
+// Component registry (#77 — implemented)
 // ---------------------------------------------------------------------------
 
-async fn list_components(_state: State<LowcodeState>) -> impl IntoResponse {
-    (StatusCode::NOT_IMPLEMENTED, "list_components")
+/// GET /api/lowcode/component → JSON array of registered component info.
+async fn list_components(state: State<LowcodeState>) -> impl IntoResponse {
+    let reg = state.registry.read().await;
+    let info = reg.list_info();
+    axum::Json(info)
 }
 
-async fn register_component(_state: State<LowcodeState>) -> impl IntoResponse {
-    (StatusCode::NOT_IMPLEMENTED, "register_component")
+/// POST /api/lowcode/component → register a new component type.
+///
+/// Accepts JSON body: `{ "type_key": "...", "category": "...", "props_schema": {...} }`
+async fn register_component(
+    state: State<LowcodeState>,
+    axum::extract::Json(body): axum::extract::Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let type_key = body.get("type_key").and_then(|v| v.as_str());
+    let category = body.get("category").and_then(|v| v.as_str());
+    let props_schema = body.get("props_schema").cloned();
+
+    let (Some(type_key), Some(category), Some(props_schema)) = (type_key, category, props_schema)
+    else {
+        return (
+            StatusCode::BAD_REQUEST,
+            axum::Json(
+                serde_json::json!({"error": "missing required fields: type_key, category, props_schema"}),
+            ),
+        );
+    };
+
+    let entry = crate::registry::ComponentEntry {
+        type_key: type_key.to_string(),
+        category: category.to_string(),
+        props_schema,
+        renderer: Box::new(|node| {
+            // Default passthrough renderer for user-registered components
+            format!(
+                r#"<div class="lc-component lc-{}">{}</div>"#,
+                node.type_key, node.props
+            )
+        }),
+    };
+
+    let mut reg = state.registry.write().await;
+    reg.register(entry);
+    (
+        StatusCode::CREATED,
+        axum::Json(serde_json::json!({"type_key": type_key, "status": "registered"})),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -133,10 +173,7 @@ pub fn lowcode_router(state: LowcodeState) -> Router {
             "/api/lowcode/layout/{id}",
             get(get_layout).put(update_layout).delete(delete_layout),
         )
-        .route(
-            "/api/lowcode/layout/{id}/node",
-            post(place_component),
-        )
+        .route("/api/lowcode/layout/{id}/node", post(place_component))
         .route(
             "/api/lowcode/layout/{id}/node/{*path}",
             patch(update_props).delete(delete_component),
@@ -151,7 +188,9 @@ pub fn lowcode_router(state: LowcodeState) -> Router {
         )
         .route(
             "/api/lowcode/template/{id}",
-            get(get_template).put(update_template).delete(delete_template),
+            get(get_template)
+                .put(update_template)
+                .delete(delete_template),
         )
         .route(
             "/api/lowcode/component",

--- a/crates/apps/addzero-lowcode/src/router.rs
+++ b/crates/apps/addzero-lowcode/src/router.rs
@@ -1,0 +1,161 @@
+/// Axum router for the lowcode service.
+
+use axum::{
+    Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, patch, post},
+};
+use uuid::Uuid;
+
+use crate::state::LowcodeState;
+
+// ---------------------------------------------------------------------------
+// Layout CRUD handlers (skeleton — handlers are todo!())
+// ---------------------------------------------------------------------------
+
+async fn create_layout(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "create_layout")
+}
+
+async fn list_layouts(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_layouts")
+}
+
+async fn get_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "get_layout")
+}
+
+async fn update_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_layout")
+}
+
+async fn delete_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_layout")
+}
+
+// ---------------------------------------------------------------------------
+// Canvas / node operations (skeleton — #78)
+// ---------------------------------------------------------------------------
+
+async fn place_component(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "place_component")
+}
+
+async fn update_props(
+    _state: State<LowcodeState>,
+    _path: Path<(Uuid, String)>,
+) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_props")
+}
+
+async fn delete_component(
+    _state: State<LowcodeState>,
+    _path: Path<(Uuid, String)>,
+) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_component")
+}
+
+// ---------------------------------------------------------------------------
+// Preview & render (skeleton — #81)
+// ---------------------------------------------------------------------------
+
+async fn preview_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "preview_layout")
+}
+
+async fn render_layout(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "render_layout")
+}
+
+// ---------------------------------------------------------------------------
+// Event handling (skeleton — #79)
+// ---------------------------------------------------------------------------
+
+async fn handle_event(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "handle_event")
+}
+
+// ---------------------------------------------------------------------------
+// Scripting (skeleton — #80)
+// ---------------------------------------------------------------------------
+
+async fn validate_script(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "validate_script")
+}
+
+// ---------------------------------------------------------------------------
+// Template CRUD (skeleton — #81)
+// ---------------------------------------------------------------------------
+
+async fn create_template(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "create_template")
+}
+
+async fn list_templates(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_templates")
+}
+
+async fn get_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "get_template")
+}
+
+async fn update_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "update_template")
+}
+
+async fn delete_template(_state: State<LowcodeState>, _id: Path<Uuid>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "delete_template")
+}
+
+// ---------------------------------------------------------------------------
+// Component registry (skeleton — #77)
+// ---------------------------------------------------------------------------
+
+async fn list_components(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "list_components")
+}
+
+async fn register_component(_state: State<LowcodeState>) -> impl IntoResponse {
+    (StatusCode::NOT_IMPLEMENTED, "register_component")
+}
+
+// ---------------------------------------------------------------------------
+// Router assembly
+// ---------------------------------------------------------------------------
+
+/// Builds the full lowcode API router.
+pub fn lowcode_router(state: LowcodeState) -> Router {
+    Router::new()
+        .route("/api/lowcode/layout", post(create_layout).get(list_layouts))
+        .route(
+            "/api/lowcode/layout/{id}",
+            get(get_layout).put(update_layout).delete(delete_layout),
+        )
+        .route(
+            "/api/lowcode/layout/{id}/node",
+            post(place_component),
+        )
+        .route(
+            "/api/lowcode/layout/{id}/node/{*path}",
+            patch(update_props).delete(delete_component),
+        )
+        .route("/api/lowcode/layout/{id}/preview", get(preview_layout))
+        .route("/api/lowcode/layout/{id}/render", get(render_layout))
+        .route("/api/lowcode/event", post(handle_event))
+        .route("/api/lowcode/script/validate", post(validate_script))
+        .route(
+            "/api/lowcode/template",
+            post(create_template).get(list_templates),
+        )
+        .route(
+            "/api/lowcode/template/{id}",
+            get(get_template).put(update_template).delete(delete_template),
+        )
+        .route(
+            "/api/lowcode/component",
+            get(list_components).post(register_component),
+        )
+        .with_state(state)
+}

--- a/crates/apps/addzero-lowcode/src/schema.rs
+++ b/crates/apps/addzero-lowcode/src/schema.rs
@@ -1,83 +1,287 @@
+//! Core Schema definitions for the lowcode platform.
+//!
+//! Three-layer data model: Layout, Component, EventBinding.
+//! All types derive serde for JSON round-trip and PG JSONB storage.
+
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// A lowcode layout — the top-level container of component nodes.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Layout {
-    pub id: Uuid,
-    pub name: String,
-    pub nodes: Vec<Node>,
-    pub created_at: String,
-    pub updated_at: String,
+// ---------------------------------------------------------------------------
+// Layout schema — the top-level design document
+// ---------------------------------------------------------------------------
+
+/// A lowcode layout: grid definition + component tree.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutSchema {
+    pub grid: GridDefinition,
+    pub children: Vec<ComponentNode>,
 }
+
+/// CSS Grid container parameters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GridDefinition {
+    pub columns: u32,
+    pub rows: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gap: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Component tree — recursive nodes placed on the grid
+// ---------------------------------------------------------------------------
 
 /// A single component node in the layout tree.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Node {
-    pub id: Uuid,
-    pub component_type: String,
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentNode {
+    pub id: String,
+    pub type_key: String,
     pub props: serde_json::Value,
-    pub children: Vec<Node>,
-    pub grid_pos: Option<GridPos>,
+    pub grid_area: GridArea,
+    #[serde(default)]
+    pub children: Vec<ComponentNode>,
 }
 
-/// Position within a CSS Grid layout.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GridPos {
-    pub col: u32,
-    pub row: u32,
-    pub col_span: u32,
-    pub row_span: u32,
+/// Position within a CSS Grid layout (1-indexed, inclusive).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GridArea {
+    pub col_start: u32,
+    pub col_end: u32,
+    pub row_start: u32,
+    pub row_end: u32,
 }
 
-/// Binds a component event to an action handler.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EventBinding {
-    pub event_name: String,
-    pub handler: EventHandler,
+// ---------------------------------------------------------------------------
+// Event bindings — component event → handler coupling
+// ---------------------------------------------------------------------------
+
+/// The action to perform when a component event fires.
+///
+/// Uses adjacently-tagged serde encoding: `{"type":"…","config":{…}}`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "config")]
+pub enum HandlerType {
+    RhaiScript { script: String },
+    HttpCall {
+        url: String,
+        method: String,
+        body_template: String,
+    },
+    EmitEvent { event_name: String },
+    Noop,
 }
 
-/// The action to perform when an event fires.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", content = "value")]
-pub enum EventHandler {
-    Navigate(String),
-    Script(String),
-    Callback(String),
-}
-
-/// Metadata for a registered component type.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ComponentDef {
-    pub type_name: String,
-    pub props_schema: serde_json::Value,
-    pub category: String,
-}
-
-/// A reusable layout template.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Template {
+/// Persisted record for an event binding row (PG `lc_event_binding`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventBindingRecord {
     pub id: Uuid,
-    pub name: String,
-    pub layout: Layout,
+    pub layout_id: Uuid,
+    pub component_path: String,
+    pub event_type: String,
+    pub handler_type: HandlerType,
     pub created_at: String,
 }
+
+// ---------------------------------------------------------------------------
+// Component registry — type metadata
+// ---------------------------------------------------------------------------
+
+/// Persisted record for a registered component type (PG `lc_component`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentDefRecord {
+    pub id: Uuid,
+    pub type_key: String,
+    pub props_schema: serde_json::Value,
+    pub category: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    pub created_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Tests — serde round-trip coverage
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn smoke_grid_pos_roundtrip() {
-        let pos = GridPos {
-            col: 1,
-            row: 2,
-            col_span: 3,
-            row_span: 4,
+    fn grid_area_roundtrip() {
+        let ga = GridArea {
+            col_start: 1,
+            col_end: 3,
+            row_start: 2,
+            row_end: 4,
         };
-        let json = serde_json::to_string(&pos).unwrap();
-        let back: GridPos = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.col, 1);
-        assert_eq!(back.row_span, 4);
+        let json = serde_json::to_string(&ga).unwrap();
+        let back: GridArea = serde_json::from_str(&json).unwrap();
+        assert_eq!(ga, back);
+    }
+
+    #[test]
+    fn component_node_roundtrip() {
+        let node = ComponentNode {
+            id: "btn-1".into(),
+            type_key: "button".into(),
+            props: serde_json::json!({ "label": "Click me" }),
+            grid_area: GridArea {
+                col_start: 1,
+                col_end: 2,
+                row_start: 1,
+                row_end: 2,
+            },
+            children: vec![],
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        let back: ComponentNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, back);
+    }
+
+    #[test]
+    fn component_node_nested_roundtrip() {
+        let child = ComponentNode {
+            id: "inner".into(),
+            type_key: "text".into(),
+            props: serde_json::json!({ "content": "hello" }),
+            grid_area: GridArea {
+                col_start: 1,
+                col_end: 2,
+                row_start: 1,
+                row_end: 2,
+            },
+            children: vec![],
+        };
+        let parent = ComponentNode {
+            id: "container".into(),
+            type_key: "div".into(),
+            props: serde_json::json!({}),
+            grid_area: GridArea {
+                col_start: 1,
+                col_end: 4,
+                row_start: 1,
+                row_end: 4,
+            },
+            children: vec![child],
+        };
+        let json = serde_json::to_string(&parent).unwrap();
+        let back: ComponentNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(parent, back);
+        assert_eq!(back.children.len(), 1);
+    }
+
+    #[test]
+    fn layout_schema_roundtrip() {
+        let layout = LayoutSchema {
+            grid: GridDefinition {
+                columns: 12,
+                rows: 8,
+                gap: Some("10px".into()),
+            },
+            children: vec![ComponentNode {
+                id: "root".into(),
+                type_key: "container".into(),
+                props: serde_json::json!({}),
+                grid_area: GridArea {
+                    col_start: 1,
+                    col_end: 13,
+                    row_start: 1,
+                    row_end: 9,
+                },
+                children: vec![],
+            }],
+        };
+        let json = serde_json::to_string(&layout).unwrap();
+        let back: LayoutSchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(layout, back);
+    }
+
+    #[test]
+    fn handler_type_rhai_roundtrip() {
+        let h = HandlerType::RhaiScript {
+            script: "print(42)".into(),
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains(r#""type":"RhaiScript""#));
+        let back: HandlerType = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn handler_type_http_roundtrip() {
+        let h = HandlerType::HttpCall {
+            url: "https://api.example.com".into(),
+            method: "POST".into(),
+            body_template: r#"{"key":"{{value}}"}"#.into(),
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains(r#""type":"HttpCall""#));
+        let back: HandlerType = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn handler_type_emit_roundtrip() {
+        let h = HandlerType::EmitEvent {
+            event_name: "onSubmit".into(),
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains(r#""type":"EmitEvent""#));
+        let back: HandlerType = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn handler_type_noop_roundtrip() {
+        let h = HandlerType::Noop;
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains(r#""type":"Noop""#));
+        let back: HandlerType = serde_json::from_str(&json).unwrap();
+        assert_eq!(h, back);
+    }
+
+    #[test]
+    fn event_binding_record_roundtrip() {
+        let rec = EventBindingRecord {
+            id: Uuid::nil(),
+            layout_id: Uuid::nil(),
+            component_path: "root/0/2".into(),
+            event_type: "onClick".into(),
+            handler_type: HandlerType::Noop,
+            created_at: "2025-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: EventBindingRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn component_def_record_roundtrip() {
+        let rec = ComponentDefRecord {
+            id: Uuid::nil(),
+            type_key: "button".into(),
+            props_schema: serde_json::json!({ "label": "string" }),
+            category: "basic".into(),
+            icon: Some("click".into()),
+            created_at: "2025-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: ComponentDefRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn component_def_record_no_icon_roundtrip() {
+        let rec = ComponentDefRecord {
+            id: Uuid::nil(),
+            type_key: "div".into(),
+            props_schema: serde_json::json!({}),
+            category: "layout".into(),
+            icon: None,
+            created_at: "2025-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        assert!(!json.contains("icon"));
+        let back: ComponentDefRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(rec, back);
     }
 }

--- a/crates/apps/addzero-lowcode/src/schema.rs
+++ b/crates/apps/addzero-lowcode/src/schema.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A lowcode layout — the top-level container of component nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Layout {
+    pub id: Uuid,
+    pub name: String,
+    pub nodes: Vec<Node>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A single component node in the layout tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    pub id: Uuid,
+    pub component_type: String,
+    pub props: serde_json::Value,
+    pub children: Vec<Node>,
+    pub grid_pos: Option<GridPos>,
+}
+
+/// Position within a CSS Grid layout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GridPos {
+    pub col: u32,
+    pub row: u32,
+    pub col_span: u32,
+    pub row_span: u32,
+}
+
+/// Binds a component event to an action handler.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventBinding {
+    pub event_name: String,
+    pub handler: EventHandler,
+}
+
+/// The action to perform when an event fires.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
+pub enum EventHandler {
+    Navigate(String),
+    Script(String),
+    Callback(String),
+}
+
+/// Metadata for a registered component type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentDef {
+    pub type_name: String,
+    pub props_schema: serde_json::Value,
+    pub category: String,
+}
+
+/// A reusable layout template.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Template {
+    pub id: Uuid,
+    pub name: String,
+    pub layout: Layout,
+    pub created_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_grid_pos_roundtrip() {
+        let pos = GridPos {
+            col: 1,
+            row: 2,
+            col_span: 3,
+            row_span: 4,
+        };
+        let json = serde_json::to_string(&pos).unwrap();
+        let back: GridPos = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.col, 1);
+        assert_eq!(back.row_span, 4);
+    }
+}

--- a/crates/apps/addzero-lowcode/src/scripting.rs
+++ b/crates/apps/addzero-lowcode/src/scripting.rs
@@ -1,0 +1,15 @@
+/// Rhai scripting engine (skeleton — to be implemented in #80).
+#[derive(Clone)]
+pub struct ScriptEngine;
+
+impl ScriptEngine {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ScriptEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/apps/addzero-lowcode/src/state.rs
+++ b/crates/apps/addzero-lowcode/src/state.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use sqlx::PgPool;
+use tokio::sync::RwLock;
 
 use crate::events::HandlerRegistry;
 use crate::registry::ComponentRegistry;
@@ -7,10 +10,12 @@ use crate::scripting::ScriptEngine;
 /// Shared application state for the lowcode service.
 ///
 /// Houses the PG pool plus in-memory registries and engines.
+/// The `ComponentRegistry` is wrapped in `Arc<RwLock<_>>` so the axum
+/// handlers can mutate it concurrently.
 #[derive(Clone)]
 pub struct LowcodeState {
     pub db: PgPool,
-    pub registry: ComponentRegistry,
+    pub registry: Arc<RwLock<ComponentRegistry>>,
     pub script_engine: ScriptEngine,
     pub handler_registry: HandlerRegistry,
 }
@@ -19,7 +24,7 @@ impl LowcodeState {
     pub fn new(db: PgPool) -> Self {
         Self {
             db,
-            registry: ComponentRegistry::new(),
+            registry: Arc::new(RwLock::new(ComponentRegistry::with_builtins())),
             script_engine: ScriptEngine::new(),
             handler_registry: HandlerRegistry::new(),
         }

--- a/crates/apps/addzero-lowcode/src/state.rs
+++ b/crates/apps/addzero-lowcode/src/state.rs
@@ -1,0 +1,27 @@
+use sqlx::PgPool;
+
+use crate::events::HandlerRegistry;
+use crate::registry::ComponentRegistry;
+use crate::scripting::ScriptEngine;
+
+/// Shared application state for the lowcode service.
+///
+/// Houses the PG pool plus in-memory registries and engines.
+#[derive(Clone)]
+pub struct LowcodeState {
+    pub db: PgPool,
+    pub registry: ComponentRegistry,
+    pub script_engine: ScriptEngine,
+    pub handler_registry: HandlerRegistry,
+}
+
+impl LowcodeState {
+    pub fn new(db: PgPool) -> Self {
+        Self {
+            db,
+            registry: ComponentRegistry::new(),
+            script_engine: ScriptEngine::new(),
+            handler_registry: HandlerRegistry::new(),
+        }
+    }
+}

--- a/crates/apps/addzero-lowcode/src/template.rs
+++ b/crates/apps/addzero-lowcode/src/template.rs
@@ -1,8 +1,18 @@
 /// Template management — save/load reusable layout templates (skeleton — to be fleshed out in #81).
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::schema::Template;
+use crate::schema::LayoutSchema;
+
+/// A reusable layout template (skeleton — will be fleshed out in #81).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Template {
+    pub id: Uuid,
+    pub name: String,
+    pub layout: LayoutSchema,
+    pub created_at: String,
+}
 
 /// Errors from template operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/apps/addzero-lowcode/src/template.rs
+++ b/crates/apps/addzero-lowcode/src/template.rs
@@ -1,0 +1,53 @@
+/// Template management — save/load reusable layout templates (skeleton — to be fleshed out in #81).
+
+use uuid::Uuid;
+
+use crate::schema::Template;
+
+/// Errors from template operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TemplateError {
+    #[error("template not found: {0}")]
+    NotFound(Uuid),
+    #[error("template validation failed: {0}")]
+    ValidationFailed(String),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+/// Template repository backed by PostgreSQL (skeleton).
+///
+/// The actual query implementations will be added alongside #81.
+pub struct TemplateRepo;
+
+impl TemplateRepo {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn create(&self, _tpl: &Template) -> Result<Template, TemplateError> {
+        todo!("template create — will be implemented in #81")
+    }
+
+    pub async fn get(&self, _id: Uuid) -> Result<Template, TemplateError> {
+        todo!("template get — will be implemented in #81")
+    }
+
+    pub async fn list(&self) -> Result<Vec<Template>, TemplateError> {
+        todo!("template list — will be implemented in #81")
+    }
+
+    pub async fn update(&self, _tpl: &Template) -> Result<Template, TemplateError> {
+        todo!("template update — will be implemented in #81")
+    }
+
+    pub async fn delete(&self, _id: Uuid) -> Result<(), TemplateError> {
+        todo!("template delete — will be implemented in #81")
+    }
+}
+
+impl Default for TemplateRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Summary

实现 issue #77 — 组件注册表（Component Registry）完整功能。

### 核心实现

**registry.rs — 完整重写：**
- `ComponentEntry` 结构体：运行时组件条目，包含 type_key、category、props_schema、renderer 闭包
- `ComponentRegistry` 完整 CRUD：register / register_from_record / unregister / get / list / list_by_category / categories
- `validate_props` — 基于 JSON Schema 的 props 校验（required 检查 + 类型检查 + enum 校验）
- `render` — 查找类型并调用注册的 renderer 产出 HTML
- `with_builtins()` — 预加载 8 个内置组件

**8 个内置组件（含 HTML renderer）：**

| type_key | category | 核心 props |
|----------|----------|-----------|
| button | basic | label, variant(primary/secondary/danger), disabled |
| input | basic | placeholder, input_type(text/email/password/number), required |
| text | basic | content, tag(p/h1-h4/span), align(left/center/right) |
| container | layout | direction(row/column), padding |
| table | data | columns[], data_source, pagination |
| form | layout | action, method(GET/POST), fields[] |
| image | media | src, alt, object_fit(cover/contain/fill) |
| divider | basic | orientation(horizontal/vertical) |

**state.rs — 并发安全改造：**
- `LowcodeState.registry` 改为 `Arc<RwLock<ComponentRegistry>>`
- 初始化时预加载 builtins

**router.rs — API 实现：**
- `GET /api/lowcode/component` → 返回所有注册组件信息
- `POST /api/lowcode/component` → 注册新组件类型（返回 201）

**lib.rs — 补充 re-export：**
- ComponentEntry, ComponentInfo, ComponentRegistry, RegistryError

### 测试（19 个新测试，总计 30 个全部通过）

- test_register_and_get / test_unregister / test_list_by_category
- test_validate_props_success / test_validate_props_missing_required / test_validate_props_wrong_type / test_validate_props_enum
- test_validate_unknown_type / test_categories / test_register_from_record
- test_render_button / test_render_button_disabled / test_render_text / test_render_container_with_children
- test_render_image / test_render_divider / test_render_unknown_type
- test_with_builtins_has_8_components / test_all_builtins_have_renderer

### 验证

- cargo check -p addzero-lowcode: OK (0 errors, 0 warnings)
- cargo test -p addzero-lowcode: OK (30 passed)

Closes #77
