### PR TITLE
fix(security): prevent Zip Slip path traversal in unpack_package

### DIFF
--- a/crates/runtime/addzero-plugin-runtime/src/lib.rs
+++ b/crates/runtime/addzero-plugin-runtime/src/lib.rs
@@ -287,11 +287,44 @@ pub fn validate_package(path: &Path) -> Result<(), RuntimeError> {
 }
 
 pub fn unpack_package(path: &Path, target_dir: &Path) -> Result<(), RuntimeError> {
+    let canonical_target = target_dir
+        .canonicalize()
+        .unwrap_or_else(|_| target_dir.to_path_buf());
+
     let file = fs::File::open(path)?;
     let mut archive = ZipArchive::new(file)?;
     for index in 0..archive.len() {
         let mut entry = archive.by_index(index)?;
-        let out_path = target_dir.join(entry.name());
+        let entry_name = entry.name();
+
+        // Reject absolute paths and entries containing path traversal components
+        if entry_name.starts_with('/')
+            || entry_name.starts_with('\\')
+            || Path::new(entry_name)
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(RuntimeError::InvalidPackage(format!(
+                "package entry `{entry_name}` contains path traversal"
+            )));
+        }
+
+        let out_path = target_dir.join(entry.sanitized_name());
+
+        // Secondary guard: canonicalized path must stay within target_dir
+        let check_path = if out_path.exists() {
+            out_path.canonicalize().ok()
+        } else {
+            out_path.parent().and_then(|p| p.canonicalize().ok())
+        };
+        if let Some(canonical_out) = check_path {
+            if !canonical_out.starts_with(&canonical_target) {
+                return Err(RuntimeError::InvalidPackage(format!(
+                    "package entry `{entry_name}` escapes target directory"
+                )));
+            }
+        }
+
         if entry.is_dir() {
             fs::create_dir_all(&out_path)?;
             continue;


### PR DESCRIPTION
Closes #110

## Summary

修复 `addzero-plugin-runtime` 中 `unpack_package()` 的 **Zip Slip 路径穿越漏洞**。

## Root Cause

原实现直接使用 `entry.name()` 作为输出路径，攻击者构造含 `../` 的 ZIP 条目名即可跳出 `target_dir`，在任意位置写入文件。

## Fix (3 层防御)

| 层 | 机制 | 说明 |
|---|---|---|
| 1 | `entry_name` 预检 | 拒绝以 `/`、`\` 开头或包含 `..` 组件的条目 |
| 2 | `entry.sanitized_name()` | zip crate 内置清理（移除前导分隔符和 `..`） |
| 3 | canonicalized path guard | 解析后路径必须 `starts_with(canonical_target_dir)` |

## Verification

- `cargo check --workspace` — 编译通过
- `cargo test --workspace` — 全部通过（`blocking_s3` 的网络超时失败为既有问题，与本次改动无关）
- 变更范围：仅 1 文件 +34 行

Automated fix by Codex.
