### PR TITLE
fix(security): redact relay_token from DeviceHello Debug output

### DIFF
--- a/crates/network/addzero-remote-protocol/src/lib.rs
+++ b/crates/network/addzero-remote-protocol/src/lib.rs
@@ -1,5 +1,7 @@
 #![forbid(unsafe_code)]
 
+use std::fmt;
+
 use addzero_remote_model::{
     ClipboardPayload, DeviceDescriptor, FileTransferEnvelope, RemoteInputEvent, SessionGrant,
     SessionRequest, VideoFrameEnvelope,
@@ -24,10 +26,20 @@ pub enum StreamKind {
     File,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeviceHello {
     pub device: DeviceDescriptor,
     pub relay_token: String,
+}
+
+impl fmt::Debug for DeviceHello {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DeviceHello")
+            .field("device", &self.device)
+            .field("relay_token", &"***")
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #94

## Summary

`DeviceHello` in `addzero-remote-protocol` was the **only remaining** config struct leaking sensitive data via `derive(Debug)`. The `relay_token` field (used for relay authentication) was printed in plaintext in debug output.

## What changed

- `crates/network/addzero-remote-protocol/src/lib.rs`: Removed `Debug` from `DeviceHello`'s derive macro and added a manual `fmt::Debug` impl that masks `relay_token` as `"***"`.

This is consistent with the pattern already used by all other sensitive structs in the workspace:
- `EmailConfig` — `password` masked
- `MqttConfig` — `password` masked  
- `SshConfig` — `password`, `private_key_passphrase` masked
- `MinioConfig` — `secret_key` masked
- `S3ClientConfig` — `secret_key` masked
- `RustfsConfig` — `secret_key` masked

## Verification

- `cargo check -p addzero-remote-protocol` ✅
- `cargo test -p addzero-remote-protocol` — 2/2 tests pass ✅

Automated fix by Codex.
