### PR TITLE
fix(knowledge): remove hardcoded Music/addzero/config-sys path

### DIFF
--- a/crates/data/addzero-knowledge/src/config.rs
+++ b/crates/data/addzero-knowledge/src/config.rs
@@ -51,11 +51,6 @@ fn default_source_specs() -> Vec<KnowledgeSourceSpec> {
             "mole",
             home.join(".config/mole"),
         ));
-        specs.push(KnowledgeSourceSpec::new(
-            "config-sys",
-            "config-sys",
-            home.join("Music/addzero/config-sys"),
-        ));
     }
 
     specs


### PR DESCRIPTION
Closes #60

## Problem
`crates/data/addzero-knowledge/src/config.rs` 中的 `default_source_specs()` 函数包含硬编码的开发者个人路径 `home.join("Music/addzero/config-sys")`，在其他机器上不存在。

## Fix
移除了 `config-sys` 这条硬编码的知识源条目。其余合理默认值（`memory`、`.config/shell`、`.config/mole`）和环境变量驱动的配置均保持不变。

## Verification
- `cargo check -p addzero-knowledge` ✅
- `cargo test -p addzero-knowledge` ✅（1 test passed）

Automated fix by Codex.