### PR TITLE
fix(skills): replace sync Path::exists()/is_dir() with tokio::fs in FsRepo

### DIFF
--- a/crates/data/addzero-skills/src/fs_repo.rs
+++ b/crates/data/addzero-skills/src/fs_repo.rs
@@ -51,7 +51,7 @@ impl FsRepo {
     /// malformed file.
     pub async fn list(&self) -> Result<Vec<Skill>> {
         let mut out = Vec::new();
-        if !self.root.exists() {
+        if !tokio::fs::try_exists(&self.root).await.unwrap_or(false) {
             return Ok(out);
         }
         let mut dir = tokio::fs::read_dir(&self.root)
@@ -59,11 +59,15 @@ impl FsRepo {
             .with_context(|| format!("read_dir {}", self.root.display()))?;
         while let Some(entry) = dir.next_entry().await? {
             let path = entry.path();
-            if !path.is_dir() {
+            let meta = match tokio::fs::metadata(&path).await {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if !meta.is_dir() {
                 continue;
             }
             let skill_md = path.join("SKILL.md");
-            if !skill_md.exists() {
+            if !tokio::fs::try_exists(&skill_md).await.unwrap_or(false) {
                 continue;
             }
             match self.read_skill(&skill_md).await {
@@ -77,7 +81,7 @@ impl FsRepo {
 
     pub async fn get(&self, name: &str) -> Result<Option<Skill>> {
         let path = self.root.join(name).join("SKILL.md");
-        if !path.exists() {
+        if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
             return Ok(None);
         }
         Ok(Some(self.read_skill(&path).await?))
@@ -85,7 +89,7 @@ impl FsRepo {
 
     pub async fn delete(&self, name: &str) -> Result<()> {
         let dir = self.root.join(name);
-        if dir.exists() {
+        if tokio::fs::try_exists(&dir).await.unwrap_or(false) {
             tokio::fs::remove_dir_all(&dir)
                 .await
                 .with_context(|| format!("remove {}", dir.display()))?;


### PR DESCRIPTION
Closes #116

## Problem
`fs_repo.rs` 中 4 个 `async fn` 使用同步 `Path::exists()` / `Path::is_dir()`，在 NFS/高并发场景下阻塞 tokio worker 线程。

## Changes
- L54 `self.root.exists()` → `tokio::fs::try_exists(&self.root).await`
- L62 `path.is_dir()` → `tokio::fs::metadata(&path).await` → `.is_dir()`
- L66 `skill_md.exists()` → `tokio::fs::try_exists(&skill_md).await`
- L80 `path.exists()` → `tokio::fs::try_exists(&path).await`
- L88 `dir.exists()` → `tokio::fs::try_exists(&dir).await`

## Verification
- ✅ `cargo check -p addzero-skills` — passed
- ✅ `cargo test -p addzero-skills` — 3 tests passed

Automated fix by Codex.